### PR TITLE
Ignore containers with invalid UUID in representation

### DIFF
--- a/client/ayon_nuke/api/constants.py
+++ b/client/ayon_nuke/api/constants.py
@@ -2,3 +2,9 @@ import os
 
 
 ASSIST = bool(os.getenv("NUKEASSIST"))
+LOADER_CATEGORY_COLORS = {
+    "latest": "0x4ecd25ff",
+    "outdated": "0xd84f20ff",
+    "invalid": "0xff0000ff",
+    "not_found": "0xffff00ff",
+}

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -804,13 +804,10 @@ def on_script_load():
 
 
 def check_inventory_versions():
-    """
-    Actual version identifier of Loaded containers
+    """Update loaded container nodes' colors based on version state.
 
-    Any time this function is run it will check all nodes and filter only
-    Loader nodes for its version. It will get all versions from database
-    and check if the node is having actual version. If not then it will color
-    it to red.
+    This will group containers by their version to outdated, not found,
+    invalid or latest and colorize the nodes based on the category.
     """
     host = registered_host()
     containers = host.get_containers()

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -50,7 +50,10 @@ from ayon_core.pipeline.colorspace import (
 )
 from ayon_core.pipeline.workfile import BuildWorkfile
 from . import gizmo_menu
-from .constants import ASSIST
+from .constants import (
+    ASSIST,
+    LOADER_CATEGORY_COLORS,
+)
 
 from .workio import save_file
 from .utils import get_node_outputs
@@ -813,18 +816,11 @@ def check_inventory_versions():
     containers = host.get_containers()
     project_name = get_current_project_name()
 
-    category_colors = {
-        "latest": "0x4ecd25ff",
-        "outdated": "0xd84f20ff",
-        "invalid": "0xff0000ff",
-        "not_found": "0xffff00ff",
-    }
-
     filtered_containers = filter_containers(containers, project_name)
     for category, containers in filtered_containers._asdict().items():
-        if category not in category_colors:
+        if category not in LOADER_CATEGORY_COLORS:
             continue
-        color = category_colors[category]
+        color = LOADER_CATEGORY_COLORS[category]
         color = int(color, 16)  # convert hex to nuke tile color int
         for container in containers:
             container["node"]["tile_color"].setValue(color)

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -825,11 +825,12 @@ def check_inventory_versions():
 
     filtered_containers = filter_containers(containers, project_name)
     for category, containers in filtered_containers._asdict().items():
-        container_color = category_colors.get(category) or category_colors["not_found"]
+        if category not in category_colors:
+            continue
+        color = category_colors[category]
+        color = int(color, 16)  # convert hex to nuke tile color int
         for container in containers:
-            container["node"]["tile_color"].setValue(
-                int(container_color, 16)
-            )
+            container["node"]["tile_color"].setValue(color)
 
 
 def writes_version_sync():


### PR DESCRIPTION
## Description
When trying to save scenes that contain OpenPype UUIDs in representations Nuke was catching this error and not allowing you to save the scene:
```
Traceback (most recent call last):
  File "/sw/nuke/15.0v4/plugins/nuke_internal/callbacks.py", line 92, in onScriptSave
    _doCallbacks(onScriptSaves)
  File "/sw/nuke/15.0v4/plugins/nuke_internal/callbacks.py", line 46, in _doCallbacks
    f[0](*f[1],**f[2])
  File "/home/lmenga/.local/share/AYON/addons/nuke_0.2.4-ax.2/ayon_nuke/api/lib.py", line 844, in check_inventory_versions
    for repre_entity in repre_entities:
  File "/pipe/ayon/release/current/dependencies/ayon_api/server_api.py", line 5967, in get_representations
    for parsed_data in query.continuous_query(self):
  File "/pipe/ayon/release/current/dependencies/ayon_api/graphql.py", line 380, in continuous_query
    raise GraphQlQueryFailed(
ayon_api.exceptions.GraphQlQueryFailed: GraphQl query Failed: Invalid entity ID 6500f58ef1d7617e88ffc758 on item 'project/representations' (Line 3 Column 5)
Traceback (most recent call last):
```
This PR fixes it by reusing existing functions that already address this issue.

## How to test
1. Create a scene and copy some nodes that contain OpenPype UUIDs
2. Save the scene