### PR TITLE
Display and View fallback options for settings and api

### DIFF
--- a/client/ayon_nuke/api/__init__.py
+++ b/client/ayon_nuke/api/__init__.py
@@ -45,7 +45,7 @@ from .lib import (
     create_write_node,
     link_knobs
 )
-from .utils import (
+from .colorspace import (
     colorspace_exists_on_node,
     get_colorspace_list
 )

--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -259,26 +259,30 @@ def get_formatted_display_and_view_as_dict(
             display_views.append(
                 {"view": view.strip(), "display": display.strip()})
 
+    root_display_and_view = get_display_and_view_colorspaces(root_node)
     for dv_item in display_views:
         # format any template tokens used in the string
-        profile = {
-            "view": StringTemplate(dv_item["view"]).format_strict(
-                formatting_data),
-            "display": StringTemplate(dv_item["display"]).format_strict(
-                formatting_data) if dv_item["display"] else None,
-        }
-        log.debug("Resolved profile: `{}`".format(profile))
-
-        # making sure formatted colorspace exists in running session
-        # also need to test case where display is None
-        test_string = profile["view"]
-        if profile["display"]:
+        view = StringTemplate.format_strict_template(
+            dv_item["view"], formatting_data
+        )
+        test_string = view
+        display = dv_item["display"]
+        if display:
+            display = StringTemplate.format_strict_template(
+                display, formatting_data
+            )
             test_string = create_viewer_profile_string(
-                profile["view"], profile["display"], path_like=False
+                view, display, path_like=False
             )
 
-        if test_string in get_display_and_view_colorspaces(root_node):
-            return profile
+        log.debug(f"Resolved View: '{view}' Display: '{display}'")
+
+        # Make sure formatted colorspace exists in running session
+        if test_string in root_display_and_view:
+            return {
+                "view": view,
+                "display": display,
+            }
 
 
 def get_formatted_colorspace(

--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -265,6 +265,7 @@ def get_formatted_display_and_view_as_dict(
         view = StringTemplate.format_strict_template(
             dv_item["view"], formatting_data
         )
+        # for config without displays - nuke_default
         test_string = view
         display = dv_item["display"]
         if display:
@@ -277,7 +278,7 @@ def get_formatted_display_and_view_as_dict(
 
         log.debug(f"Resolved View: '{view}' Display: '{display}'")
 
-        # Make sure formatted colorspace exists in running session
+        # Make sure formatted colorspace exists in running ocio config session
         if test_string in root_display_and_view:
             return {
                 "view": view,

--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -21,7 +21,7 @@ DISPLAY_AND_VIEW_COLORSPACES_CACHE = {}
 COLORSPACES_CACHE = {}
 
 
-def get_display_and_view_colorspaces(root_node: nuke.Node) -> list:
+def get_display_and_view_colorspaces(root_node):
     """Get all possible display and view colorspaces
 
     This is stored in class variable to avoid multiple calls.
@@ -43,10 +43,7 @@ def get_display_and_view_colorspaces(root_node: nuke.Node) -> list:
     return DISPLAY_AND_VIEW_COLORSPACES_CACHE[script_name]
 
 
-def get_colorspace_list(
-    colorspace_knob: nuke.Knob,
-    node: nuke.Node = None,
-) -> list:
+def get_colorspace_list(colorspace_knob, node=None):
     """Get available colorspace profile names
 
     Args:
@@ -84,7 +81,7 @@ def get_colorspace_list(
     return COLORSPACES_CACHE[identifier_key]
 
 
-def colorspace_exists_on_node(node: nuke.Node, colorspace_name: str) -> bool:
+def colorspace_exists_on_node(node, colorspace_name):
     """ Check if colorspace exists on node
 
     Look through all options in the colorspace knob, and see if we have an
@@ -110,7 +107,7 @@ def colorspace_exists_on_node(node: nuke.Node, colorspace_name: str) -> bool:
     return colorspace_name in get_colorspace_list(colorspace_knob, node)
 
 
-def create_viewer_profile_string(viewer, display=None, path_like=False) -> str:
+def create_viewer_profile_string(viewer, display=None, path_like=False):
     """Convert viewer and display to string
 
     Args:
@@ -130,10 +127,7 @@ def create_viewer_profile_string(viewer, display=None, path_like=False) -> str:
 
 
 def get_formatted_display_and_view(
-    view_profile: dict,
-    formatting_data: dict,
-    root_node: nuke.Node = None,
-) -> str:
+        view_profile, formatting_data, root_node=None):
     """Format display and view profile into string.
 
     This method is formatting a display and view profile. It is iterating
@@ -209,10 +203,7 @@ def get_formatted_display_and_view(
 
 
 def get_formatted_display_and_view_as_dict(
-    view_profile: dict,
-    formatting_data: dict,
-    root_node: nuke.Node = None,
-) -> dict:
+        view_profile, formatting_data, root_node=None):
     """Format display and view profile into dict.
 
     This method is formatting a display and view profile. It is iterating
@@ -296,10 +287,7 @@ def get_formatted_display_and_view_as_dict(
 
 
 def get_formatted_colorspace(
-    colorspace_name: str,
-    formatting_data: dict,
-    root_node: nuke.Node = None,
-) -> str:
+        colorspace_name, formatting_data, root_node=None):
     """Format colorspace profile name into string.
 
     This method is formatting colorspace profile name. It is iterating

--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -1,0 +1,363 @@
+"""
+Nuke Colorspace related methods
+"""
+
+from logging import root
+import re
+
+from ayon_core.lib import (
+    Logger,
+    StringTemplate,
+)
+
+from .constants import COLOR_VALUE_SEPARATOR
+
+import nuke
+
+log = Logger.get_logger(__name__)
+
+
+DISPLAY_AND_VIEW_COLORSPACES_CACHE = {}
+COLORSPACES_CACHE = {}
+
+
+def get_display_and_view_colorspaces(root_node: nuke.Node) -> list:
+    """Get all possible display and view colorspaces
+
+    This is stored in class variable to avoid multiple calls.
+
+    Args:
+        root_node (nuke.Node): root node
+
+    Returns:
+        list: all possible display and view colorspaces
+    """
+    global DISPLAY_AND_VIEW_COLORSPACES_CACHE
+
+    script_name = nuke.root().name()
+    if not DISPLAY_AND_VIEW_COLORSPACES_CACHE.get(script_name):
+        colorspace_knob = root_node["monitorLut"]
+        colorspaces = nuke.getColorspaceList(colorspace_knob)
+        DISPLAY_AND_VIEW_COLORSPACES_CACHE[script_name] = colorspaces
+
+    return DISPLAY_AND_VIEW_COLORSPACES_CACHE[script_name]
+
+
+def get_colorspace_list(
+    colorspace_knob: nuke.Knob,
+    node: nuke.Node = None,
+) -> list:
+    """Get available colorspace profile names
+
+    Args:
+        colorspace_knob (nuke.Knob): nuke knob object
+        node (Optional[nuke.Node]): nuke node for caching differentiation
+
+    Returns:
+        list: list of strings names of profiles
+    """
+    results = []
+
+    # making sure any node is provided
+    node = node or nuke.root()
+    # unique script based identifier
+    script_name = nuke.root().name()
+    node_name = node.fullName()
+    identifier_key = f"{script_name}_{node_name}"
+
+    if not COLORSPACES_CACHE.get(identifier_key):
+        # This pattern is to match with roles which uses an indentation and
+        # parentheses with original colorspace. The value returned from the
+        # colorspace is the string before the indentation, so we'll need to
+        # convert the values to match with value returned from the knob,
+        # ei. knob.value().
+        pattern = r".*\t.* \(.*\)"
+        for colorspace in nuke.getColorspaceList(colorspace_knob):
+            match = re.search(pattern, colorspace)
+            if match:
+                results.append(colorspace.split("\t", 1)[0])
+            else:
+                results.append(colorspace)
+
+        COLORSPACES_CACHE[identifier_key] = results
+
+    return COLORSPACES_CACHE[identifier_key]
+
+
+def colorspace_exists_on_node(node: nuke.Node, colorspace_name: str) -> bool:
+    """ Check if colorspace exists on node
+
+    Look through all options in the colorspace knob, and see if we have an
+    exact match to one of the items.
+
+    Args:
+        node (nuke.Node): nuke node object
+        colorspace_name (str): color profile name
+
+    Returns:
+        bool: True if exists
+    """
+    node_knob_keys = node.knobs().keys()
+
+    if "colorspace" in node_knob_keys:
+        colorspace_knob = node["colorspace"]
+    elif "floatLut" in node_knob_keys:
+        colorspace_knob = node["floatLut"]
+    else:
+        log.warning(f"Node '{node.name()}' does not have colorspace knob")
+        return False
+
+    return colorspace_name in get_colorspace_list(colorspace_knob, node)
+
+
+def create_viewer_profile_string(viewer, display=None, path_like=False) -> str:
+    """Convert viewer and display to string
+
+    Args:
+        viewer (str): viewer name
+        display (Optional[str]): display name
+        path_like (Optional[bool]): if True, return path like string
+
+    Returns:
+        str: viewer config string
+    """
+    if not display:
+        return viewer
+
+    if path_like:
+        return "{}/{}".format(display, viewer)
+    return "{} ({})".format(viewer, display)
+
+
+def get_formatted_display_and_view(
+    view_profile: dict,
+    formatting_data: dict,
+    root_node: nuke.Node = None,
+) -> str:
+    """Format display and view profile into string.
+
+    This method is formatting a display and view profile. It is iterating
+    over all possible combinations of display and view colorspaces. Those
+    could be separated by COLOR_VALUE_SEPARATOR defined in constants.
+
+    If Anatomy template tokens are used but formatting data is not provided,
+    it will try any other available variants in next position of the separator.
+
+    This method also validate that the formatted display and view profile is
+    available in currently run nuke session ocio config.
+
+    Example:
+        >>> from ayon_nuke.api.colorspace import get_formatted_display_and_view
+        >>> view_profile = {
+        ...     "view": "{context};sRGB",
+        ...     "display": "{project_code};ACES"
+        ... }
+        >>> formatting_data = {
+        ...    "context": "01sh010",
+        ...    "project_code": "proj01"
+        ...}
+        >>> display_and_view = get_formatted_display_and_view(
+        ...    view_profile, formatting_data)
+        >>> print(display_and_view)
+        "01sh010 (proj01)"
+
+
+    Args:
+        view_profile (dict): view and display profile
+        formatting_data (dict): formatting data
+        root_node (Optional[nuke.Node]): root node
+
+    Returns:
+        str: formatted display and view profile string
+            ex: "sRGB (ACES)"
+    """
+    if not root_node:
+        root_node = nuke.root()
+
+    views = [view_profile["view"]]
+    displays = []
+
+    # display could be optional in case nuke_default ocio config is used
+    if view_profile["display"]:
+        displays.append(view_profile["display"])
+
+    # separate all values by path separator
+    if COLOR_VALUE_SEPARATOR in view_profile["view"]:
+        views = view_profile["view"].split(COLOR_VALUE_SEPARATOR)
+    if COLOR_VALUE_SEPARATOR in view_profile["display"]:
+        displays = view_profile["display"].split(COLOR_VALUE_SEPARATOR)
+
+    # generate all possible combination of display/view
+    display_views = []
+    for view in views:
+
+        if displays:
+            for display in displays:
+                display_views.append(
+                    create_viewer_profile_string(
+                        view.strip(), display.strip(), path_like=False
+                    )
+                )
+        else:
+            display_views.append(view.strip())
+
+    for dv_item in display_views:
+        # format any template tokens used in the string
+        dv_item_resolved = StringTemplate(dv_item).format_strict(
+            formatting_data)
+        log.debug("Resolved display and view: `{}`".format(dv_item_resolved))
+
+        # making sure formatted colorspace exists in running session
+        if dv_item_resolved in get_display_and_view_colorspaces(root_node):
+            return dv_item_resolved
+
+
+def get_formatted_display_and_view_as_dict(
+    view_profile: dict,
+    formatting_data: dict,
+    root_node: nuke.Node = None,
+) -> dict:
+    """Format display and view profile into dict.
+
+    This method is formatting a display and view profile. It is iterating
+    over all possible combinations of display and view colorspaces. Those
+    could be separated by COLOR_VALUE_SEPARATOR defined in constants.
+
+    If Anatomy template tokens are used but formatting data is not provided,
+    it will try any other available variants in next position of the separator.
+
+    This method also validate that the formatted display and view profile is
+    available in currently run nuke session ocio config.
+
+    Example:
+        >>> from ayon_nuke.api.colorspace import get_formatted_display_and_view_as_dict  # noqa
+        >>> view_profile = {
+        ...     "view": "{context};sRGB",
+        ...     "display": "{project_code};ACES"
+        ... }
+        >>> formatting_data = {
+        ...    "context": "01sh010",
+        ...    "project_code": "proj01"
+        ...}
+        >>> display_and_view = get_formatted_display_and_view_as_dict(
+        ...    view_profile, formatting_data)
+        >>> print(display_and_view)
+        {"view": "01sh010", "display": "proj01"}
+
+
+    Args:
+        view_profile (dict): view and display profile
+        formatting_data (dict): formatting data
+        root_node (Optional[nuke.Node]): root node
+
+    Returns:
+        dict: formatted display and view profile in dict
+            ex: {"view": "sRGB", "display": "ACES"}
+    """
+    if not root_node:
+        root_node = nuke.root()
+
+    views = [view_profile["view"]]
+    displays = []
+
+    # display could be optional in case nuke_default ocio config is used
+    if view_profile["display"]:
+        displays.append(view_profile["display"])
+
+    # separate all values by path separator
+    if COLOR_VALUE_SEPARATOR in view_profile["view"]:
+        views = view_profile["view"].split(COLOR_VALUE_SEPARATOR)
+    if COLOR_VALUE_SEPARATOR in view_profile["display"]:
+        displays = view_profile["display"].split(COLOR_VALUE_SEPARATOR)
+
+    # generate all possible combination of display/view
+    display_views = []
+    for view in views:
+
+        if displays:
+            for display in displays:
+                display_views.append(
+                    {"view": view.strip(), "display": display.strip()})
+        else:
+            display_views.append({"view": view.strip(), "display": None})
+
+    for dv_item in display_views:
+        # format any template tokens used in the string
+        profile = {
+            "view": StringTemplate(dv_item["view"]).format_strict(
+                formatting_data),
+            "display": StringTemplate(dv_item["display"]).format_strict(
+                formatting_data) if dv_item["display"] else None,
+        }
+        log.debug("Resolved profile: `{}`".format(profile))
+
+        # making sure formatted colorspace exists in running session
+        # also need to test case where display is None
+        test_string = profile["view"]
+        if profile["display"]:
+            test_string = create_viewer_profile_string(
+                profile["view"], profile["display"], path_like=False
+            )
+
+        if test_string in get_display_and_view_colorspaces(root_node):
+            return profile
+
+
+def get_formatted_colorspace(
+    colorspace_name: str,
+    formatting_data: dict,
+    root_node: nuke.Node = None,
+) -> str:
+    """Format colorspace profile name into string.
+
+    This method is formatting colorspace profile name. It is iterating
+    over all possible combinations of input string which could be separated
+    by COLOR_VALUE_SEPARATOR defined in constants.
+
+    If Anatomy template tokens are used but formatting data is not provided,
+    it will try any other available variants in next position of the separator.
+
+    This method also validate that the formatted colorspace profile name is
+    available in currently run nuke session ocio config.
+
+    Example:
+        >>> from ayon_nuke.api.colorspace import get_formatted_colorspace
+        >>> colorspace_name = "{project_code}_{context};ACES - ACEScg"
+        >>> formatting_data = {
+        ...    "context": "01sh010",
+        ...    "project_code": "proj01"
+        ...}
+        >>> new_colorspace_name = get_formatted_colorspace(
+        ...    colorspace_name, formatting_data)
+        >>> print(new_colorspace_name)
+        "proj01_01sh010"
+
+
+    Args:
+        colorspace_name (str): colorspace profile name
+        formatting_data (dict): formatting data
+        root_node (Optional[nuke.Node]): root node
+
+    Returns:
+        str: formatted colorspace profile string
+            ex: "ACES - ACEScg"
+    """
+    if not root_node:
+        root_node = nuke.root()
+
+    colorspaces = [colorspace_name]
+
+    # separate all values by path separator
+    if COLOR_VALUE_SEPARATOR in colorspace_name:
+        colorspaces = colorspace_name.split(COLOR_VALUE_SEPARATOR)
+
+    # iterate via all found colorspaces
+    for citem in colorspaces:
+        # format any template tokens used in the string
+        citem_resolved = StringTemplate(citem.strip()).format_strict(
+            formatting_data)
+        log.debug("Resolved colorspace: `{}`".format(citem_resolved))
+
+        # making sure formatted colorspace exists in running session
+        if colorspace_exists_on_node(root_node, citem_resolved):
+            return citem_resolved

--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -2,7 +2,6 @@
 Nuke Colorspace related methods
 """
 
-from logging import root
 import re
 
 from ayon_core.lib import (

--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -174,18 +174,14 @@ def get_formatted_display_and_view(
     if not root_node:
         root_node = nuke.root()
 
-    views = [view_profile["view"]]
-    displays = []
+    views = view_profile["view"].split(COLOR_VALUE_SEPARATOR)
+    displays = view_profile["display"].split(COLOR_VALUE_SEPARATOR)
 
     # display could be optional in case nuke_default ocio config is used
     if view_profile["display"]:
-        displays.append(view_profile["display"])
-
-    # separate all values by path separator
-    if COLOR_VALUE_SEPARATOR in view_profile["view"]:
-        views = view_profile["view"].split(COLOR_VALUE_SEPARATOR)
-    if COLOR_VALUE_SEPARATOR in view_profile["display"]:
         displays = view_profile["display"].split(COLOR_VALUE_SEPARATOR)
+    else:
+        displays = []
 
     # generate all possible combination of display/view
     display_views = []
@@ -257,18 +253,14 @@ def get_formatted_display_and_view_as_dict(
     if not root_node:
         root_node = nuke.root()
 
-    views = [view_profile["view"]]
-    displays = []
+    views = view_profile["view"].split(COLOR_VALUE_SEPARATOR)
+    displays = view_profile["display"].split(COLOR_VALUE_SEPARATOR)
 
     # display could be optional in case nuke_default ocio config is used
     if view_profile["display"]:
-        displays.append(view_profile["display"])
-
-    # separate all values by path separator
-    if COLOR_VALUE_SEPARATOR in view_profile["view"]:
-        views = view_profile["view"].split(COLOR_VALUE_SEPARATOR)
-    if COLOR_VALUE_SEPARATOR in view_profile["display"]:
         displays = view_profile["display"].split(COLOR_VALUE_SEPARATOR)
+    else:
+        displays = []
 
     # generate all possible combination of display/view
     display_views = []
@@ -345,11 +337,7 @@ def get_formatted_colorspace(
     if not root_node:
         root_node = nuke.root()
 
-    colorspaces = [colorspace_name]
-
-    # separate all values by path separator
-    if COLOR_VALUE_SEPARATOR in colorspace_name:
-        colorspaces = colorspace_name.split(COLOR_VALUE_SEPARATOR)
+    colorspaces = colorspace_name.split(COLOR_VALUE_SEPARATOR)
 
     # iterate via all found colorspaces
     for citem in colorspaces:

--- a/client/ayon_nuke/api/constants.py
+++ b/client/ayon_nuke/api/constants.py
@@ -2,3 +2,5 @@ import os
 
 
 ASSIST = bool(os.getenv("NUKEASSIST"))
+
+COLOR_VALUE_SEPARATOR = ";"

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -53,7 +53,6 @@ from . import gizmo_menu
 from .constants import (
     ASSIST,
     LOADER_CATEGORY_COLORS,
-    COLOR_VALUE_SEPARATOR,
 )
 
 from .workio import save_file

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -43,7 +43,6 @@ from .lib import (
     get_filenames_without_hash,
     get_work_default_directory,
     link_knobs,
-    format_anatomy,
 )
 from .pipeline import (
     list_instances,

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -41,13 +41,17 @@ from .lib import (
     get_node_data,
     get_view_process_node,
     get_filenames_without_hash,
-    link_knobs
+    link_knobs,
+    format_anatomy,
 )
 from .pipeline import (
     list_instances,
     remove_instance
 )
-from ayon_nuke.api.lib import format_anatomy
+from .colorspace import (
+    get_formatted_display_and_view_as_dict,
+    get_formatted_colorspace
+)
 
 
 def _collect_and_cache_nodes(creator):
@@ -964,25 +968,27 @@ class ExporterReviewMov(ExporterReview):
                 if baking_colorspace["type"] == "display_view":
                     display_view = baking_colorspace["display_view"]
 
+                    display_view_f = get_formatted_display_and_view_as_dict(
+                        display_view, self.formatting_data
+                    )
+
+                    if not display_view_f:
+                        raise ValueError(
+                            "Invalid display and view profile: "
+                            f"'{display_view}'"
+                        )
+
+                    # assign display and view
+                    display = display_view_f["display"]
+                    view = display_view_f["view"]
+
                     message = "OCIODisplay...   '{}'"
                     node = nuke.createNode("OCIODisplay")
 
-                    # assign display and view
-                    display = display_view["display"]
-                    view = display_view["view"]
-
                     # display could not be set in nuke_default config
                     if display:
-                        # format display string with anatomy data
-                        display = StringTemplate(display).format_strict(
-                            self.formatting_data
-                        )
                         node["display"].setValue(display)
 
-                    # format view string with anatomy data
-                    view = StringTemplate(view).format_strict(
-                        self.formatting_data)
-                    # assign viewer
                     node["view"].setValue(view)
 
                     if config_data:
@@ -996,8 +1002,13 @@ class ExporterReviewMov(ExporterReview):
                 elif baking_colorspace["type"] == "colorspace":
                     baking_colorspace = baking_colorspace["colorspace"]
                     # format colorspace string with anatomy data
-                    baking_colorspace = StringTemplate(
-                        baking_colorspace).format_strict(self.formatting_data)
+                    baking_colorspace = get_formatted_colorspace(
+                        baking_colorspace, self.formatting_data
+                    )
+                    if not baking_colorspace:
+                        raise ValueError(
+                            f"Invalid baking color space: '{baking_colorspace}'"
+                        )
                     node = nuke.createNode("OCIOColorSpace")
                     message = "OCIOColorSpace...   '{}'"
                     # no need to set input colorspace since it is driven by

--- a/client/ayon_nuke/api/utils.py
+++ b/client/ayon_nuke/api/utils.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 import nuke
 
@@ -91,55 +90,6 @@ def bake_gizmos_recursively(in_group=None):
 
                 if node.Class() == "Group":
                     bake_gizmos_recursively(node)
-
-
-def colorspace_exists_on_node(node, colorspace_name):
-    """ Check if colorspace exists on node
-
-    Look through all options in the colorspace knob, and see if we have an
-    exact match to one of the items.
-
-    Args:
-        node (nuke.Node): nuke node object
-        colorspace_name (str): color profile name
-
-    Returns:
-        bool: True if exists
-    """
-    try:
-        colorspace_knob = node['colorspace']
-    except ValueError:
-        # knob is not available on input node
-        return False
-
-    return colorspace_name in get_colorspace_list(colorspace_knob)
-
-
-def get_colorspace_list(colorspace_knob):
-    """Get available colorspace profile names
-
-    Args:
-        colorspace_knob (nuke.Knob): nuke knob object
-
-    Returns:
-        list: list of strings names of profiles
-    """
-    results = []
-
-    # This pattern is to match with roles which uses an indentation and
-    # parentheses with original colorspace. The value returned from the
-    # colorspace is the string before the indentation, so we'll need to
-    # convert the values to match with value returned from the knob,
-    # ei. knob.value().
-    pattern = r".*\t.* \(.*\)"
-    for colorspace in nuke.getColorspaceList(colorspace_knob):
-        match = re.search(pattern, colorspace)
-        if match:
-            results.append(colorspace.split("\t", 1)[0])
-        else:
-            results.append(colorspace)
-
-    return results
 
 
 def is_headless():

--- a/server/settings/common.py
+++ b/server/settings/common.py
@@ -147,15 +147,23 @@ class DisplayAndViewProfileModel(BaseSettingsModel):
     display: str = SettingsField(
         "",
         title="Display",
-        description="What display to use",
+        description=(
+            "What display to use. Anatomy context tokens can "
+            "be used to dynamically set the value. And also fallback can "
+            "be defined via ';' (semicolon) separator. \n"
+            "Example: \n'{project[code]} ; ACES'.\n"
+            "Note that we are stripping the spaces around the separator."
+        ),
     )
-
     view: str = SettingsField(
         "",
         title="View",
         description=(
             "What view to use. Anatomy context tokens can "
-            "be used to dynamically set the value."
+            "be used to dynamically set the value. And also fallback can "
+            "be defined via ';' separator. \nExample: \n"
+            "'{project[code]}_{parent}_{folder[name]} ; sRGB'.\n"
+            "Note that we are stripping the spaces around the separator."
         ),
     )
 

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -146,14 +146,23 @@ class ViewProcessModel(BaseSettingsModel):
     display: str = SettingsField(
         "",
         title="Display",
-        description="What display to use",
+        description=(
+            "What display to use. Anatomy context tokens can "
+            "be used to dynamically set the value. And also fallback can "
+            "be defined via ';' (semicolon) separator. \n"
+            "Example: \n'{project[code]} ; ACES'.\n"
+            "Note that we are stripping the spaces around the separator."
+        ),
     )
     view: str = SettingsField(
         "",
         title="View",
         description=(
             "What view to use. Anatomy context tokens can "
-            "be used to dynamically set the value."
+            "be used to dynamically set the value. And also fallback can "
+            "be defined via ';' separator. \nExample: \n"
+            "'{project[code]}_{parent}_{folder[name]} ; sRGB'.\n"
+            "Note that we are stripping the spaces around the separator."
         ),
     )
 
@@ -164,14 +173,23 @@ class MonitorProcessModel(BaseSettingsModel):
     display: str = SettingsField(
         "",
         title="Display",
-        description="What display to use",
+        description=(
+            "What display to use. Anatomy context tokens can "
+            "be used to dynamically set the value. And also fallback can "
+            "be defined via ';' (semicolon) separator. \n"
+            "Example: \n'{project[code]} ; ACES'.\n"
+            "Note that we are stripping the spaces around the separator."
+        ),
     )
     view: str = SettingsField(
         "",
         title="View",
         description=(
             "What view to use. Anatomy context tokens can "
-            "be used to dynamically set the value."
+            "be used to dynamically set the value. And also fallback can "
+            "be defined via ';' separator. \nExample: \n"
+            "'{project[code]}_{parent}_{folder[name]} ; sRGB'.\n"
+            "Note that we are stripping the spaces around the separator."
         ),
     )
 


### PR DESCRIPTION
After adding support for context-specific anatomy token resolution in color management display and view options, we must now ensure value validation and provide fallback options. We're introducing a semicolon separator in values, allowing for multiple options where the order is important.


## Additional informations
- colorspace methods were moved from lib to new nuke API module `colorspace.py`. Some of those function might need to move into core addon but for now lets keep them here. 

## Testing notes
### Pre testing 
- version up dev number in package.py
- deploy addon version to your server and bundle
- make sure core colormanagement is enabled
- notice hints on `ayon+settings://nuke/imageio/viewer/display` 

### How to do DCC testing
- When conducting this testing, it is important to note that a published ocio config may not be present in your task context. Our objective is to determine the backward compatibility of the process and identify any potential issues.  It is possible for only certain shot folders to have published ocio configurations, while others may not. In such scenarios, a fallback option must be available. 
- In addition to this PR, the changes in https://github.com/ynput/ayon-core/pull/834 also need to be deployed. Once completed, the colorspace settings in the core addon should be adjusted to use the fallback option. The built-in **ACES 1.2** should be selected for this purpose.


1. To test baking targeting it would be good to disable clearing nodes in your code here **ayon-nuke\client\ayon_nuke\api\plugin.py:1090** - just add `#` on line start. Then after open Nuke. This way baking nodes created during **ExtractReviewIntermediates** processing will stay in script and you would be able to check how they are set. 

2. Follow next setps where we fork into two different testing
	a. _Baking Target Colorspace (Use Display & View)_
			- set `{project[code]}_{parent}_{folder[name]};sRGB` into View here **ayon+settings://nuke/imageio/baking_target/display_view/view**
			- Go to Nuke and publish render node
			- Check what is set into node just before write node.
			- it should be set to **sRGB** if ocio config is set to different then published product.
			
	b. _Baking Target Colorspace (Use Colorspace)_
			- set `{project[code]}_{parent}_{folder[name]};Output - Rec.709` into View here **ayon+settings://nuke/imageio/baking_target/colorspace**
			- Go to Nuke and publish render node
			- Check what is set into node just before write node.
			- it should be set to **Output - Rec.709** if ocio config is set to different then published product.