### PR TITLE
Fix write node creation while broken project Anatomy.

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -887,7 +887,7 @@ def check_product_name_exists(nodes, product_name):
                 False)
 
 
-def format_anatomy(data):
+def get_work_default_directory(data):
     ''' Helping function for formatting of anatomy paths
 
     Arguments:
@@ -924,7 +924,10 @@ def format_anatomy(data):
         },
         "frame": "#" * frame_padding,
     })
-    return anatomy.format(data)
+
+    work_default_dir_template = anatomy.get_template_item("work", "default", "directory")
+    normalized_dir = work_default_dir_template.format_strict(data).normalized()
+    return str(normalized_dir).replace("\\", "/")
 
 
 def script_name():
@@ -1100,13 +1103,9 @@ def create_write_node(
         "imageio_writes": imageio_writes,
         "ext": ext
     })
-    anatomy_filled = format_anatomy(data)
 
     # build file path to workfiles
-    fdir = str(
-        anatomy_filled["work"]["default"]["directory"]
-    ).replace("\\", "/")
-    data["work"] = fdir
+    data["work"] = get_work_default_directory(data)
     fpath = StringTemplate(data["fpath_template"]).format_strict(data)
 
     # create directory

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -47,7 +47,7 @@ from .pipeline import (
     list_instances,
     remove_instance
 )
-from ayon_nuke.api.lib import format_anatomy
+from ayon_nuke.api.lib import get_work_default_directory
 
 
 def _collect_and_cache_nodes(creator):
@@ -1275,13 +1275,9 @@ def update_write_node_filepath(created_inst, changes):
         "{work}/renders/nuke/{subset}/{subset}.{frame}.{ext}"),
         "ext": write_node["file_type"].value()
     })
-    anatomy_filled = format_anatomy(formatting_data)
 
     # build file path to workfiles
-    fdir = str(
-        anatomy_filled["work"]["default"]["directory"]
-    ).replace("\\", "/")
-    formatting_data["work"] = fdir
+    formatting_data["work"] = get_work_default_directory(formatting_data)
     fpath = StringTemplate(formatting_data["fpath_template"]).format_strict(
         formatting_data)
     write_node["file"].setValue(fpath)


### PR DESCRIPTION
## Changelog Description

Address #9 

I Implemented the solution suggested by @BigRoy on the associated issue which makes perfect sense:
* scoped the anatomy resolve to the required scoped template when creating a Write node
* No more resolving all templates when we use a single entry


## Testing notes:

1. Set broken Anatomy preset for something irrelevant to the Write node creation
(note additional `]` after variant)
![image](https://github.com/user-attachments/assets/00e4a79d-75ab-4de3-899d-61f1977d9551)

2. Open Nuke and create a Write node from AYON -> Create
3. Ensure a write node get properly created despite part of the Anatomy being wrong

