### PR TITLE
Use task attributes for WorkfileSettings

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1397,7 +1397,8 @@ class WorkfileSettings(object):
             project_name, self._folder_path
         )
         self._task_name = get_current_task_name()
-        self._context_label = "{} > {}".format(self._folder_path, task_name)
+        self._context_label = "{} > {}".format(self._folder_path,
+                                               self._task_name)
         self._task_entity = ayon_api.get_task_by_name(
             project_name,
             self._folder_entity["id"],

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1393,9 +1393,15 @@ class WorkfileSettings(object):
         Context._project_entity = project_entity
         self._project_name = project_name
         self._folder_path = get_current_folder_path()
-        self._task_name = get_current_task_name()
         self._folder_entity = ayon_api.get_folder_by_path(
             project_name, self._folder_path
+        )
+        self._task_name = get_current_task_name()
+        self._context_label = "{} > {}".format(self._folder_path, task_name)
+        self._task_entity = ayon_api.get_task_by_name(
+            project_name,
+            self._folder_entity["id"],
+            self._task_name
         )
         self._root_node = root_node or nuke.root()
         self._nodes = self.get_nodes(nodes=nodes)
@@ -1907,39 +1913,39 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
     def reset_frame_range_handles(self):
         """Set frame range to current folder."""
 
-        if "attrib" not in self._folder_entity:
-            msg = "Folder {} don't have set any 'attrib'".format(
-                self._folder_path
+        if "attrib" not in self._task_entity:
+            msg = "Task {} doesn't have set any 'attrib'".format(
+                self._context_label
             )
             log.warning(msg)
             nuke.message(msg)
             return
 
-        folder_attributes = self._folder_entity["attrib"]
+        task_attributes = self._task_entity["attrib"]
 
         missing_cols = []
         check_cols = ["fps", "frameStart", "frameEnd",
                       "handleStart", "handleEnd"]
 
         for col in check_cols:
-            if col not in folder_attributes:
+            if col not in task_attributes:
                 missing_cols.append(col)
 
         if len(missing_cols) > 0:
             missing = ", ".join(missing_cols)
-            msg = "'{}' are not set for folder '{}'!".format(
-                missing, self._folder_path)
+            msg = "'{}' are not set for task '{}'!".format(
+                missing, self._context_label)
             log.warning(msg)
             nuke.message(msg)
             return
 
         # get handles values
-        handle_start = folder_attributes["handleStart"]
-        handle_end = folder_attributes["handleEnd"]
-        frame_start = folder_attributes["frameStart"]
-        frame_end = folder_attributes["frameEnd"]
+        handle_start = task_attributes["handleStart"]
+        handle_end = task_attributes["handleEnd"]
+        frame_start = task_attributes["frameStart"]
+        frame_end = task_attributes["frameEnd"]
 
-        fps = float(folder_attributes["fps"])
+        fps = float(task_attributes["fps"])
         frame_start_handle = frame_start - handle_start
         frame_end_handle = frame_end + handle_end
 
@@ -1979,12 +1985,12 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
         """Set resolution to project resolution."""
         log.info("Resetting resolution")
         project_name = get_current_project_name()
-        folder_attributes = self._folder_entity["attrib"]
+        task_attributes = self._task_entity["attrib"]
 
         format_data = {
-            "width": folder_attributes["resolutionWidth"],
-            "height": folder_attributes["resolutionHeight"],
-            "pixel_aspect": folder_attributes["pixelAspect"],
+            "width": task_attributes["resolutionWidth"],
+            "height": task_attributes["resolutionHeight"],
+            "pixel_aspect": task_attributes["pixelAspect"],
             "name": project_name
         }
 

--- a/client/ayon_nuke/plugins/publish/validate_script_attributes.py
+++ b/client/ayon_nuke/plugins/publish/validate_script_attributes.py
@@ -34,7 +34,7 @@ class ValidateScriptAttributes(
         # Task may be optional for an instance
         task_entity = instance.data.get("taskEntity")
         if task_entity:
-            src_attributes = task_entity["attributes"]
+            src_attributes = task_entity["attrib"]
         else:
             src_attributes = instance.data["folderEntity"]["attrib"]
 

--- a/client/ayon_nuke/plugins/publish/validate_script_attributes.py
+++ b/client/ayon_nuke/plugins/publish/validate_script_attributes.py
@@ -31,7 +31,12 @@ class ValidateScriptAttributes(
 
         script_data = deepcopy(instance.context.data["scriptData"])
 
-        src_folder_attributes = instance.data["folderEntity"]["attrib"]
+        # Task may be optional for an instance
+        task_entity = instance.data.get("taskEntity")
+        if task_entity:
+            src_attributes = task_entity["attributes"]
+        else:
+            src_attributes = instance.data["folderEntity"]["attrib"]
 
         # These attributes will be checked
         attributes = [
@@ -44,15 +49,15 @@ class ValidateScriptAttributes(
             "handleEnd"
         ]
 
-        # get only defined attributes from folder data
-        folder_attributes = {
-            attr: src_folder_attributes[attr]
+        # get only defined attributes from folder or task data
+        check_attributes = {
+            attr: src_attributes[attr]
             for attr in attributes
-            if attr in src_folder_attributes
+            if attr in src_attributes
         }
         # fix frame values to include handles
-        folder_attributes["fps"] = float("{0:.4f}".format(
-            folder_attributes["fps"]))
+        check_attributes["fps"] = float("{0:.4f}".format(
+            check_attributes["fps"]))
         script_data["fps"] = float("{0:.4f}".format(
             script_data["fps"]))
 
@@ -62,14 +67,14 @@ class ValidateScriptAttributes(
             self.log.debug(
                 "Folder vs Script attribute \"{}\": {}, {}".format(
                     attr,
-                    folder_attributes[attr],
+                    check_attributes[attr],
                     script_data[attr]
                 )
             )
-            if folder_attributes[attr] != script_data[attr]:
+            if check_attributes[attr] != script_data[attr]:
                 not_matching.append({
                     "name": attr,
-                    "expected": folder_attributes[attr],
+                    "expected": check_attributes[attr],
                     "actual": script_data[attr]
                 })
 

--- a/client/ayon_nuke/plugins/publish/validate_script_attributes.py
+++ b/client/ayon_nuke/plugins/publish/validate_script_attributes.py
@@ -65,7 +65,7 @@ class ValidateScriptAttributes(
         not_matching = []
         for attr in attributes:
             self.log.debug(
-                "Folder vs Script attribute \"{}\": {}, {}".format(
+                "Task vs Script attribute \"{}\": {}, {}".format(
                     attr,
                     check_attributes[attr],
                     script_data[attr]


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Workfile resolution and FPS is now set using the current task's entity attribute instead of from the parent folder entity.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

I didn't test it.

## Testing notes:

Create a folder with a task where the task has different FPS and resolution.

1. Create new workfile - settings should adhere to task attributes
2. Use "Reset resolution" and "Reset frame range" menu actions - it should set it using the task attributes
3. Publishing validations should also adhere to the task attributes, not the folder entity attributes. (If there are any validators for that.)