### PR TITLE
Implement Extract Nuke camera as FBX file.

### DIFF
--- a/client/ayon_nuke/api/__init__.py
+++ b/client/ayon_nuke/api/__init__.py
@@ -14,7 +14,8 @@ from .plugin import (
     NukeWriteCreator,
     NukeCreatorError,
     get_instance_group_node_childs,
-    get_colorspace_from_node
+    get_colorspace_from_node,
+    get_publish_config
 )
 from .pipeline import (
     NukeHost,

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -487,6 +487,11 @@ def get_review_presets_config():
     return [str(name) for name, _prop in outputs.items()]
 
 
+def get_publish_config():
+    settings = get_current_project_settings()
+    return settings["nuke"].get("publish", {})
+
+
 class NukeLoader(LoaderPlugin):
     container_id_knob = "containerId"
     container_id = None

--- a/client/ayon_nuke/plugins/publish/extract_camera.py
+++ b/client/ayon_nuke/plugins/publish/extract_camera.py
@@ -7,6 +7,7 @@ import pyblish.api
 
 from ayon_core.pipeline import publish
 from ayon_nuke.api.lib import maintained_selection
+from ayon_nuke.api.plugin import get_publish_config
 
 
 class ExtractCamera(publish.Extractor):
@@ -19,14 +20,37 @@ class ExtractCamera(publish.Extractor):
 
     settings_category = "nuke"
 
-    # presets
-    write_geo_knobs = [
-        ("file_type", "abc"),
-        ("storageFormat", "Ogawa"),
-        ("writeGeometries", False),
-        ("writePointClouds", False),
-        ("writeAxes", False)
-    ]
+    def _get_camera_export_presets(self, instance):
+        """
+        Args:
+            instance (dict): The current instance being published.
+
+        Returns:
+            presets (list.): The camera export presets to use.
+        """
+        write_geo_knobs = [
+            ("writeGeometries", False),
+            ("writePointClouds", False),
+            ("writeAxes", False)
+        ]
+
+        publish_settings = get_publish_config()
+        extract_camera_settings = publish_settings.get("ExtractCameraFormat", {})
+        export_camera_settings = extract_camera_settings.get("export_camera_format", "abc")
+
+        if export_camera_settings == "abc":
+            write_geo_knobs.insert(0, ("file_type", "abc"))
+            write_geo_knobs.append((("storageFormat", "Ogawa")))
+
+        elif export_camera_settings == "fbx":
+            write_geo_knobs.insert(0, ("file_type", "fbx"))            
+            write_geo_knobs.append(("writeLights", False))            
+
+        else:
+            raise ValueError("Invalid Camera export format: %s" % export_format)
+
+        return write_geo_knobs
+
 
     def process(self, instance):
         camera_node = instance.data["transientData"]["node"]
@@ -43,7 +67,8 @@ class ExtractCamera(publish.Extractor):
         staging_dir = self.staging_dir(instance)
 
         # get extension form preset
-        extension = next((k[1] for k in self.write_geo_knobs
+        export_presets = self._get_camera_export_presets(instance)
+        extension = next((k[1] for k in export_presets
                           if k[0] == "file_type"), None)
         if not extension:
             raise RuntimeError(
@@ -68,7 +93,7 @@ class ExtractCamera(publish.Extractor):
             wg_n = nuke.createNode("WriteGeo")
             wg_n["file"].setValue(file_path)
             # add path to write to
-            for k, v in self.write_geo_knobs:
+            for k, v in export_presets:
                 wg_n[k].setValue(v)
             rm_nodes.append(wg_n)
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -32,6 +32,14 @@ def nuke_product_types_enum():
     ] + nuke_render_publish_types_enum()
 
 
+def nuke_export_formats_enum():
+    """Return all nuke export format available in creators."""
+    return [
+        {"value": "abc", "label": "Alembic"},
+        {"value": "fbx", "label": "FBX"},    
+    ]
+
+
 class NodeModel(BaseSettingsModel):
     name: str = SettingsField(
         title="Node name"
@@ -186,6 +194,15 @@ class FVFXScopeOfWorkModel(BaseSettingsModel):
     template: str = SettingsField(title="Template")
 
 
+class ExtractCameraFormatModel(BaseSettingsModel):
+    export_camera_format: str = SettingsField(
+        enum_resolver=nuke_export_formats_enum,
+        conditionalEnum=True,
+        title="Camera export format",
+        description="Switch between different camera export formats",
+    )
+
+
 class ExctractSlateFrameParamModel(BaseSettingsModel):
     f_submission_note: FSubmissionNoteModel = SettingsField(
         title="f_submission_note",
@@ -259,6 +276,10 @@ class PublishPluginsModel(BaseSettingsModel):
             title="Extract Review Intermediates",
             default_factory=ExtractReviewIntermediatesModel
         )
+    )
+    ExtractCameraFormat: ExtractCameraFormatModel = SettingsField(
+        title="Extract Camera Format",
+        default_factory=ExtractCameraFormatModel        
     )
     ExtractSlateFrame: ExtractSlateFrameModel = SettingsField(
         title="Extract Slate Frame",
@@ -386,6 +407,9 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
                 "add_custom_tags": []
             }
         ]
+    },
+    "ExtractCameraFormat": {
+        "export_camera_format": "abc",
     },
     "ExtractSlateFrame": {
         "viewer_lut_raw": False,


### PR DESCRIPTION
## Changelog Description

This PR addresses: AY-6599
* Add support to extract camera as FBX file
* Add a new package server setting for a switch between ABC and FBX
* Ensure loader support generated FBX properly


## Additional info
Tested with Nuke 15.1v2

## Testing notes:

1. Build ayon-nuke package and upload it to server
2. Ensure Export to FBX is set in newly added `Nuke -> Publish Plugins -> Extract Camera Format` presets
![image](https://github.com/user-attachments/assets/841b49e6-1e98-4cd9-96f2-d6babe4f6f3d)

3. Create and Publish a new camera from Nuke
4. Ensure resulting camera can be properly loaded back
