### PR TITLE
disabled raw data on clip when setting colorspace

### DIFF
--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -422,6 +422,7 @@ class LoadClip(plugin.NukeLoader):
         ):
             self.log.info(f"Used colorspace: {used_colorspace}")
             read_node["colorspace"].setValue(used_colorspace)
+            read_node["raw"].setValue(False)
         else:
             self.log.info("Colorspace not set...")
 


### PR DESCRIPTION
## Changelog Description
When loading a clip with a colorspace set, ie through File Rules, _Raw Data_ should be disabled on the read nodes. Just saves one click and a potential artist error


## Additional info
first PR!

## Testing notes:

1. Configure a file rule following the official Ayon core addon docs
2. Load in a clip. I used an exr of product type plate
3. Check "raw" knob
