### PR TITLE
Publishing review intermediates - always add anatomy output keyword

### DIFF
--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -628,6 +628,7 @@ class ExporterReview(object):
         add_tags = tags or []
         repre = {
             "name": self.name,
+            "outputName": self.name,
             "ext": self.ext,
             "files": self.file,
             "stagingDir": self.staging_dir,
@@ -636,7 +637,8 @@ class ExporterReview(object):
                 # making sure that once intermediate file is published
                 # as representation, we will be able to then identify it
                 # from representation.data.isIntermediate
-                "isIntermediate": True
+                "isIntermediate": True,
+                "isMultiIntermediates": self.multiple_presets
             },
         }
 
@@ -652,9 +654,6 @@ class ExporterReview(object):
             filenames = get_filenames_without_hash(
                 self.file, self.first_frame, self.last_frame)
             repre["files"] = filenames
-
-        if self.multiple_presets:
-            repre["outputName"] = self.name
 
         if self.publish_on_farm:
             repre["tags"].append("publish_on_farm")


### PR DESCRIPTION
## Changelog Description
The {output} anatomy keyword is now respected even if there is only one Extract Review Intermediate profile.

Having the published output as a one and only imagery in the folder helps apps Like Hiero to not get confused while searching for versions.

## Additional info
resolves https://github.com/ynput/ayon-nuke/issues/32

## Testing notes:

1. Make sure you have only one Extract Review Intermediate profile
2. Set anatomy render directory template to ```{root[work]}/{project[name]}/{hierarchy}/{folder[name]}/publish/{product[type]}/{product[name]}/{@version}/<_{output}>```
3. Publish Nuke render
4. Check publish folder structure
