### PR TITLE
Nuke behavior more resilient

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -588,7 +588,6 @@ def read_avalon_data(node):
     if result:
         first_user_knob = result.group(2)
         # Collect user knobs from the end of the knob list
-        node_name = node['name'].value()
         for knob in reversed(node.allKnobs()):
             knob_name = knob.name()
             if not knob_name:
@@ -597,8 +596,9 @@ def read_avalon_data(node):
             try:
                 knob_type = nuke.knob(knob.fullyQualifiedName(), type=True)
                 value = knob.value()
-            except Exception as e:
-                log.debug(f"Error reading knob {knob_name} from node {node_name}")
+            except Exception:
+                log.debug(
+                    f"Error in knob {knob_name}, node {node['name'].value()}")
                 continue
             if (
                 knob_type not in EXCLUDED_KNOB_TYPE_ON_READ or


### PR DESCRIPTION
## Changelog Description
Ayon uses onScriptSave callback to update nodes' colors. If this fails by any reason, artist is not able to save the file.

Nuke sometimes fails on getting knob type needed in ```read_avalon_data```. This can result in artisn not being able to open workfile. Reason unknown, hard to test.

Changes allow artist to continue working.

## Additional info
Might close https://github.com/ynput/ayon-nuke/issues/33

## Testing notes:
1. Launch Nuke, open Workfile
2. Make changes
3. Stop server
4. Save file with Control + S
