### PR TITLE
find_free_space_to_paste_node errors if the script is completely empty

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2210,6 +2210,11 @@ def find_free_space_to_paste_nodes(
                      [n.ypos() + n.screenHeight() for n in nuke.allNodes()
                       if n not in nodes]
 
+        if len(group_xpos) == 0:
+            group_xpos = [0]
+        if len(group_ypos) == 0:
+            group_ypos = [0]
+
         # calc output left
         if direction in "left":
             xpos = min(group_xpos) - abs(nodes_screen_width) - abs(offset)


### PR DESCRIPTION
## Changelog Description
Sets the default position of the imported nodes to 0,0 if there are no nodes in the script

## Testing notes:
1. Delete everything
2. Import nuke nodes via the Loader
