### PR TITLE
Add lensDistortion product type for loading gizmo

### DIFF
--- a/client/ayon_nuke/plugins/load/load_gizmo.py
+++ b/client/ayon_nuke/plugins/load/load_gizmo.py
@@ -21,7 +21,7 @@ from ayon_nuke.api import (
 class LoadGizmo(load.LoaderPlugin):
     """Loading nuke Gizmo"""
 
-    product_types = {"gizmo"}
+    product_types = {"gizmo", "lensDistortion"}
     representations = {"*"}
     extensions = {"nk"}
 


### PR DESCRIPTION
## Changelog Description
Fixes: #38 

- Add `lensDistortion` as product type that can be loaded as a gizmo in Nuke.

## Testing notes:
1. Publish a lensDistortion product from 3DE
2. Open Nuke
3. Open the loader and right click > load gizmo on the published lens distortion
