### PR TITLE
Disable AYON_LOG_NO_COLORS in prelaunch hook

### DIFF
--- a/client/ayon_nuke/addon.py
+++ b/client/ayon_nuke/addon.py
@@ -45,7 +45,8 @@ class NukeAddon(AYONAddon, IHostAddon):
 
         # Set default values if are not already set via settings
         defaults = {
-            "LOGLEVEL": "DEBUG"
+            "LOGLEVEL": "DEBUG",
+            "AYON_LOG_NO_COLORS": "1",
         }
         for key, value in defaults.items():
             if not env.get(key):


### PR DESCRIPTION
## Changelog Description
Fixes #24 

- Sets `AYON_LOG_NO_COLORS` to `1` in `add_implementation_envs` in `NukeAddon` class

## Testing notes:
1. Open Nuke from AYON
2. The logs appear correctly
