### PR TITLE
Easier Addon Setting for Nodes settings in color management section 

### DIFF
--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -11,12 +11,24 @@ from .common import (
     ColorspaceConfigurationModel,
 )
 
+def nuke_creator_plugins_enum():
+    return [
+        {"value": "CreateWritePrerender", "label": "Prerender (write)"},
+        {"value": "CreateCamera", "label": "Camera (3d)"},
+        {"value": "CreateGizmo", "label": "Gizmo (group)"},
+        {"value": "CreateWriteImage", "label": "Image (write)"},
+        {"value": "CreateModel", "label": "Model (3d)"},
+        {"value": "CreateBackdrop", "label": "Nukenodes (backdrop)"},
+        {"value": "CreateWriteRender", "label": "Render (write)"},
+        {"value": "CreateSource", "label": "Source (read)"},
+    ]
 
 class NodesModel(BaseSettingsModel):
     _layout = "expanded"
     plugins: list[str] = SettingsField(
         default_factory=list,
-        title="Used in plugins"
+        title="Used in plugins",
+        enum_resolver=nuke_creator_plugins_enum
     )
     nuke_node_class: str = SettingsField(
         title="Nuke Node Class",


### PR DESCRIPTION
## Changelog Description
resolve #42 
Reuse the names/labels that admins/nuke artists are familiar with.
where the setting shows a drop down menu and select the creators

| Publisher | Settings |
|--|--|
| ![Image](https://github.com/user-attachments/assets/12bc8a6a-237e-4982-be15-e57827ebeb6d) |  ![Image](https://github.com/user-attachments/assets/0d2844b9-34a7-454b-9d05-f8d64d884ca1) |

Should we do the same with `Nuke Node class`
![image](https://github.com/user-attachments/assets/8d3adbe9-d009-41d9-8d66-b945b8d19ed4)


## Additional Info 
I was modifying the code to take a neat screenshot but it turns out that the small modification actually works as before.

## Testing notes:
1. Creating Nuke node should work as before. 