### PR TITLE
Fix deprecated default settings in `Custom Tools` and `Gizmo Menu`

### DIFF
--- a/server/settings/gizmo.py
+++ b/server/settings/gizmo.py
@@ -51,7 +51,7 @@ class GizmoItem(BaseSettingsModel):
 
 
 DEFAULT_GIZMO_ITEM = {
-    "toolbar_menu_name": "OpenPype Gizmo",
+    "toolbar_menu_name": "AYON Gizmo",
     "gizmo_source_dir": {
         "windows": [],
         "darwin": [],
@@ -69,7 +69,7 @@ DEFAULT_GIZMO_ITEM = {
                 {
                     "sourcetype": "python",
                     "title": "Gizmo Note",
-                    "command": "nuke.nodes.StickyNote(label='You can create your own toolbar menu in the Nuke GizmoMenu of OpenPype')",
+                    "command": "nuke.nodes.StickyNote(label='You can create your own toolbar menu in the Nuke GizmoMenu of AYON.')",
                     "icon": "",
                     "shortcut": ""
                 }

--- a/server/settings/scriptsmenu.py
+++ b/server/settings/scriptsmenu.py
@@ -45,7 +45,7 @@ DEFAULT_SCRIPTSMENU_SETTINGS = {
             "type": "action",
             "sourcetype": "python",
             "title": "Set non publish output for Write Node",
-            "command": "from from ayon_nuke.startup.custom_write_node import main;main();",  # noqa
+            "command": "from ayon_nuke.startup.custom_write_node import main; main();",  # noqa
             "tooltip": "Set up write nodes for non-publish"
         }
     ]

--- a/server/settings/scriptsmenu.py
+++ b/server/settings/scriptsmenu.py
@@ -38,15 +38,15 @@ DEFAULT_SCRIPTSMENU_SETTINGS = {
             "type": "action",
             "sourcetype": "python",
             "title": "Set Frame Start (Read Node)",
-            "command": "from openpype.hosts.nuke.startup.frame_setting_for_read_nodes import main;main();",  # noqa
+            "command": "from ayon_nuke.startup.frame_setting_for_read_nodes import main;main();",  # noqa
             "tooltip": "Set frame start for read node(s)"
         },
         {
             "type": "action",
             "sourcetype": "python",
             "title": "Set non publish output for Write Node",
-            "command": "from openpype.hosts.nuke.startup.custom_write_node import main;main();",  # noqa
-            "tooltip": "Open the OpenPype Nuke user doc page"
+            "command": "from from ayon_nuke.startup.custom_write_node import main;main();",  # noqa
+            "tooltip": "Set up write nodes for non-publish"
         }
     ]
 }


### PR DESCRIPTION
## Changelog Description
resolve #44 

## Testing notes:
1. Custom Tools in Nuke should now work with the default settings
![image](https://github.com/user-attachments/assets/f5ce61a8-9842-41a8-b899-7fb40908de41)
2. Everything should work as before.
