### PR TITLE
Easier `Gizmo Menu` settings

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2522,8 +2522,9 @@ def add_scripts_gizmo():
         toolbar_name = gizmo_settings["toolbar_menu_name"]
 
         toolbar_icon_path = gizmo_settings["toolbar_icon_path"][platform_name]
-        toolbar_icon_path = StringTemplate.format_template(
-            toolbar_icon_path, template_data)
+        if toolbar_icon_path:
+            toolbar_icon_path = StringTemplate.format_template(
+                toolbar_icon_path, template_data)
 
         # Create the toolbar
         toolbar_menu = GizmoMenu(
@@ -2539,14 +2540,17 @@ def add_scripts_gizmo():
 
         if option == "gizmo_source_dir":
             gizmo_paths_to_add = gizmos[platform_name]
-            gizmo_paths_to_add = StringTemplate.format_template(
-                gizmo_paths_to_add, template_data)
-            toolbar_menu.add_gizmo_path(gizmo_paths_to_add)
+            if gizmo_paths_to_add:
+                gizmo_paths_to_add = StringTemplate.format_template(
+                    gizmo_paths_to_add, template_data)
+                toolbar_menu.add_gizmo_path(gizmo_paths_to_add)
         elif option == "gizmo_definition":
             for gizmo in gizmos:
                 for gizmo_item in gizmo["sub_gizmo_list"]:
-                    gizmo_item["icon"] = StringTemplate.format_template(
-                        gizmo_item["icon"], template_data)
+                    gizmo_item_icon = gizmo_item["icon"]
+                    if gizmo_item_icon:
+                        gizmo_item["icon"] = StringTemplate.format_template(
+                            gizmo_item_icon, template_data)
             toolbar_menu.build_from_configuration(gizmos)
 
 

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -1,5 +1,6 @@
 import re
 from typing import Any
+from copy import deepcopy
 
 
 def _get_viewer_config_from_string(input_string):
@@ -128,6 +129,46 @@ def _convert_extract_intermediate_files_0_2_3(publish_overrides):
             }
 
 
+def _convert_gizmo_menu_0_3_1(overrides):
+    if "gizmo" not in overrides:
+        return
+    
+    old_gizmos = overrides["gizmo"]
+    new_gizmos = []
+    
+    # Gizmo menu settings prior to the Nuke addon version `0.3.1` 
+    # included a combined setting for both `Gizmo directory path`
+    # and `Gizmo definitions`. 
+    # In the new, simplified settings, the gizmo menu was split
+    # so that each menu item is either `Gizmo directory path` or
+    # `Gizmo definitions`, with the `option` reflecting the selection.
+    # This conversion code reconstructs the gizmo menu settings to 
+    # achieve that.
+
+    for gizmo in old_gizmos:
+        # Already new setting
+        if "options" in gizmo:
+            return
+        
+        # Check if it has `Gizmo Directory Path`
+        if any(gizmo["gizmo_source_dir"].values()):
+            tmp_gizmo = deepcopy(gizmo)
+            tmp_gizmo["options"] = "gizmo_source_dir"
+            tmp_gizmo.pop("gizmo_definition")
+            new_gizmos.append(tmp_gizmo)
+
+        # Check if it has `Gizmo Definition`
+        gizmo_definition = gizmo["gizmo_definition"]
+        if gizmo_definition:
+            tmp_gizmo = deepcopy(gizmo)
+            tmp_gizmo["options"] = "gizmo_definition"
+            tmp_gizmo.pop("gizmo_source_dir")
+            new_gizmos.append(tmp_gizmo)
+    
+    # Override using the new gizmo
+    overrides["gizmo"] = new_gizmos          
+
+
 def _convert_publish_plugins(overrides):
     if "publish" not in overrides:
         return
@@ -138,6 +179,7 @@ def convert_settings_overrides(
     source_version: str,
     overrides: dict[str, Any],
 ) -> dict[str, Any]:
+    _convert_gizmo_menu_0_3_1(overrides)
     _convert_imageio_configs_0_2_3(overrides)
     _convert_publish_plugins(overrides)
     return overrides

--- a/server/settings/gizmo.py
+++ b/server/settings/gizmo.py
@@ -26,10 +26,24 @@ class SubGizmoItem(BaseSettingsModel):
 
 class GizmoDefinitionItem(BaseSettingsModel):
     gizmo_toolbar_path: str = SettingsField(
-        title="Gizmo Menu"
+        title="Gizmo Menu Parent",
+        description="Leave it empty to use the toolbar menu name as parent."
     )
     sub_gizmo_list: list[SubGizmoItem] = SettingsField(
         default_factory=list, title="Sub Gizmo List")
+
+
+def gizmo_enum_options():
+    return [
+        {
+            "value": "gizmo_source_dir",
+            "label": "Add a Gizmo Directory Path"
+        },
+        {
+            "value": "gizmo_definition",
+            "label": "Add Gizmos by Definitions"
+        }
+    ]
 
 
 class GizmoItem(BaseSettingsModel):
@@ -38,13 +52,21 @@ class GizmoItem(BaseSettingsModel):
     toolbar_menu_name: str = SettingsField(
         title="Toolbar Menu Name"
     )
+    toolbar_icon_path: MultiplatformPathModel = SettingsField(
+        default_factory=MultiplatformPathModel,
+        title="Toolbar Icon Path",
+        description="Leave it empty to use the AYON icon."
+    )
+    options: str = SettingsField(
+        "gizmo_source_dir",
+        title="Gizmo Menu Options",
+        description="Switch between gizmo menu options",
+        enum_resolver=gizmo_enum_options,
+        conditionalEnum=True
+    )
     gizmo_source_dir: MultiplatformPathListModel = SettingsField(
         default_factory=MultiplatformPathListModel,
         title="Gizmo Directory Path"
-    )
-    toolbar_icon_path: MultiplatformPathModel = SettingsField(
-        default_factory=MultiplatformPathModel,
-        title="Toolbar Icon Path"
     )
     gizmo_definition: list[GizmoDefinitionItem] = SettingsField(
         default_factory=list, title="Gizmo Definition")
@@ -64,7 +86,7 @@ DEFAULT_GIZMO_ITEM = {
     },
     "gizmo_definition": [
         {
-            "gizmo_toolbar_path": "/path/to/menu",
+            "gizmo_toolbar_path": "",
             "sub_gizmo_list": [
                 {
                     "sourcetype": "python",

--- a/server/settings/gizmo.py
+++ b/server/settings/gizmo.py
@@ -62,7 +62,8 @@ class GizmoItem(BaseSettingsModel):
         title="Gizmo Menu Options",
         description="Switch between gizmo menu options",
         enum_resolver=gizmo_enum_options,
-        conditionalEnum=True
+        conditionalEnum=True,
+        section="Gizmos"
     )
     gizmo_source_dir: MultiplatformPathListModel = SettingsField(
         default_factory=MultiplatformPathListModel,

--- a/server/settings/gizmo.py
+++ b/server/settings/gizmo.py
@@ -75,16 +75,17 @@ class GizmoItem(BaseSettingsModel):
 
 DEFAULT_GIZMO_ITEM = {
     "toolbar_menu_name": "AYON Gizmo",
-    "gizmo_source_dir": {
-        "windows": [],
-        "darwin": [],
-        "linux": []
-    },
     "toolbar_icon_path": {
         "windows": "",
         "darwin": "",
         "linux": ""
     },
+    "options": "gizmo_definition",
+    "gizmo_source_dir": {
+        "windows": [],
+        "darwin": [],
+        "linux": []
+    },    
     "gizmo_definition": [
         {
             "gizmo_toolbar_path": "",

--- a/server/settings/gizmo.py
+++ b/server/settings/gizmo.py
@@ -30,7 +30,7 @@ class GizmoDefinitionItem(BaseSettingsModel):
         description="Leave it empty to use the toolbar menu name as parent."
     )
     sub_gizmo_list: list[SubGizmoItem] = SettingsField(
-        default_factory=list, title="Sub Gizmo List")
+        default_factory=list, title="Gizmo List")
 
 
 def gizmo_enum_options():


### PR DESCRIPTION
## Changelog Description
resolve #46 
- [x] Enhance gizmo settings `ayon+settings://nuke/gizmo`
- [x] Enhance loading logic [here](https://github.com/ynput/ayon-nuke/blob/1cf07f89eb948f8e16b4487cb09554058b8d0ad9/client/ayon_nuke/api/lib.py#L2499-L2561).
- [x] Implement Setting Conversion.
- [x] Support using template keys and environment variables.

> [!Note]
> Changes in this PR are inspired by the UX of the [`Shelves Manager`](https://ayon.ynput.io/docs/addon_houdini_admin#shelves-manager) in Houdini  addon settings.
> I've realize that Houdini docs are abit old.
> <details><summary>so here's a screenshot</summary>
>
> ![image](https://github.com/user-attachments/assets/a62102f1-be05-44d0-a99c-b353ecc063e0)
> </details>

## Demo
Settings:
- Mode 1: Add a Gizmo Directory Path
![image](https://github.com/user-attachments/assets/f65f17bb-af98-4201-b7c5-c4db3e517dbe)
- Mode 2: Add Gizmos By definitions
![image](https://github.com/user-attachments/assets/74738b31-f990-40ac-9096-7703c4fc8825)

## Testing notes:
1. Test `copy settings` from older version.. values from older addon version should be propagated properly to the new version.
2. Try using different options `Gizmo Menu`. e.g. use `gizmo directory path`, use `gizmo definition` list.
3. Try using [template keys](https://ayon.ynput.io/docs/admin_settings_project_anatomy/#available-template-keys), roots or environment variables in any file path location in gizmo menu.
4. When launching Nuke, Gizmo should be added as configured in the settings.
5. if there's no `toolbar icon path`, AYON icon will be used instead.