### PR TITLE
Fix use of stagingDir

### DIFF
--- a/client/ayon_nuke/plugins/publish/collect_nuke_instance_data.py
+++ b/client/ayon_nuke/plugins/publish/collect_nuke_instance_data.py
@@ -58,10 +58,14 @@ class CollectInstanceData(pyblish.api.InstancePlugin):
         staging_dir_persistent = instance.data["transientData"].get(
             "stagingDir_persistent", False
         )
+        staging_dir_is_custom = instance.data["transientData"].get(
+            "stagingDir_is_custom", False
+        )
         if staging_dir:
             instance.data.update({
                 "stagingDir": staging_dir,
-                "stagingDir_persistent": staging_dir_persistent
+                "stagingDir_persistent": staging_dir_persistent,
+                "stagingDir_is_custom": staging_dir_is_custom,
             })
 
         self.log.debug("Collected instance: {}".format(

--- a/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
+++ b/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
@@ -37,12 +37,12 @@ class ExtractReviewIntermediates(publish.Extractor):
 
         task_type = instance.context.data["taskType"]
         product_name = instance.data["productName"]
-        self.log.debug("Creating staging dir...")
 
         if "representations" not in instance.data:
             instance.data["representations"] = []
 
-        if not instance.data.get("stagingDir"):
+        # use instance's stagingDir only if explicitly custom
+        if not instance.data.get("stagingDir_is_custom"):
             instance.data["stagingDir"] = os.path.normpath(
                 os.path.dirname(instance.data["path"]))
 

--- a/package.py
+++ b/package.py
@@ -6,6 +6,6 @@ client_dir = "ayon_nuke"
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">=1.0.12",
+    "core": ">=1.0.13",
 }
 ayon_compatible_addons = {}


### PR DESCRIPTION
## Changelog Description
Use stagingDir on instance only if it is explicitly set as custom, in other case fall back to old implementation which produces baking script next in `work/../renders`.


## Additional review information
This solves issue in `extract_review_intermediates` when now there was `stagingDir` on instance suddenly. This resulted in creation of baking script in `tempdir` which got purged at the end of publishing via `Clean Up` plugin.

This PR is variant of similar issue in Maya https://github.com/ynput/ayon-maya/pull/212

## Testing notes:
1. publish in Nuke via Deadline
2. baking step shouldnt fail