### PR TITLE
Fix error missing arguments after addUserKnob

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -972,7 +972,7 @@ def add_button_clear_rendered(node, path):
     name = "clearRendered"
     label = "Clear Rendered"
     value = "import clear_rendered;\
-        clear_rendered.clear_rendered(\"{}\")".format(path)
+        clear_rendered.clear_rendered('{}')".format(path)
     knob = nuke.PyScript_Knob(name, label, value)
     node.addKnob(knob)
 


### PR DESCRIPTION
## Changelog Description
- Replaces double quotes by single quotes in the `add_button_clear_rendered` function that adds Python code in a PyScript knob

## Additional review information
The details are explained here: https://community.ynput.io/t/nuke-and-deadline-error-rendercompositingmain-missing-arguments-after-adduserknob/1957

## Testing notes:
1. Open Nuke
2. Create a Render (write) publish instance
3. Use Farm rendering
4. Publish it and see the job on the farm, there shouldn't be any errors

Tagging @jakubjezek001 
