### PR TITLE
Update version constraints for core addon

### DIFF
--- a/package.py
+++ b/package.py
@@ -6,6 +6,6 @@ client_dir = "ayon_nuke"
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">=1.0.13",
+    "core": ">1.0.13",
 }
 ayon_compatible_addons = {}


### PR DESCRIPTION
Changed the core addon requirement from ">=1.0.13" to ">1.0.13" to ensure compatibility with newer versions only.
