### PR TITLE
Fix returned colorspace list in `get_colorspace_list` - AY-7415

### DIFF
--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -46,8 +46,8 @@ def get_colorspace_list(colorspace_knob, node=None, consider_aliases=True):
     Args:
         colorspace_knob (nuke.Knob): nuke knob object
         node (Optional[nuke.Node]): nuke node for caching differentiation
-        consider_aliases (bool): optional flag to indicate if colorspace
-        aliases should be added to results list
+        consider_aliases (Optional[bool]): optional flag to indicate if
+        colorspace aliases should be added to results list
 
     Returns:
         list: list of strings names of profiles

--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -40,12 +40,14 @@ def get_display_and_view_colorspaces(root_node):
     return _DISPLAY_AND_VIEW_COLORSPACES_CACHE[script_name]
 
 
-def get_colorspace_list(colorspace_knob, node=None):
+def get_colorspace_list(colorspace_knob, node=None, consider_aliases=True):
     """Get available colorspace profile names
 
     Args:
         colorspace_knob (nuke.Knob): nuke knob object
         node (Optional[nuke.Node]): nuke node for caching differentiation
+        consider_aliases (bool): optional flag to indicate if colorspace
+        aliases should be added to results list
 
     Returns:
         list: list of strings names of profiles
@@ -68,7 +70,10 @@ def get_colorspace_list(colorspace_knob, node=None):
         pattern = r"[\t,]+"
         for colorspace in nuke.getColorspaceList(colorspace_knob):
             colorspace_and_aliases = re.split(pattern, colorspace)
-            results.append(colorspace_and_aliases[0])
+            if consider_aliases:
+                results.extend(colorspace_and_aliases)
+            else:
+                results.append(colorspace_and_aliases[0])
 
         _COLORSPACES_CACHE[identifier_key] = results
 

--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -65,13 +65,10 @@ def get_colorspace_list(colorspace_knob, node=None):
         # colorspace is the string before the indentation, so we'll need to
         # convert the values to match with value returned from the knob,
         # ei. knob.value().
-        pattern = r".*\t.* \(.*\)"
+        pattern = r"[\t,]+"
         for colorspace in nuke.getColorspaceList(colorspace_knob):
-            match = re.search(pattern, colorspace)
-            if match:
-                results.append(colorspace.split("\t", 1)[0])
-            else:
-                results.append(colorspace)
+            colorspace_and_aliases = re.split(pattern, colorspace)
+            results.append(colorspace_and_aliases[0])
 
         _COLORSPACES_CACHE[identifier_key] = results
 


### PR DESCRIPTION
[Here](https://github.com/ynput/ayon-nuke/issues/59) the related issue.

## Changelog Description

In ACES 1.3 some of the colorspaces returned by `nuke.getColorspaceList` are in the form of a single string containing the colorspace name and its aliases separated by the tab character "\t" or a comma. E.g. `"ACES2065-1\t\taces2065_1,ACES - ACES2065-1,lin_ap0"`. This was not being taken in to account when adding colorspaces to the `results` list. 

For instance, here some of the resulting colorspace list without the fix: 
```python
[
        "default (Gamma2.2)",
        "aces_interchange",
        "cie_xyz_d65_interchange",
        "color_picking",
        "color_timing",
        "compositing_log",
        "data",
        "matte_paint",
        "scene_linear",
        "texture_paint",
        "ACES2065-1\t\taces2065_1,ACES - ACES2065-1,lin_ap0",
        "ACEScc\t\tACES - ACEScc,acescc_ap1",
        "ACEScct\t\tACES - ACEScct,acescct_ap1",
        "ACEScg\t\tACES - ACEScg,lin_ap1",
        ...
    ]
```
This makes function `colorspace_exists_on_node` to always return `False` if we set a colorspace by using its name in file rules instead of a role.  `return "ACES2065-1" in get_colorspace_list(colorspace_knob, node)` won't match as the `in` operator in list expects a full match, unlike strings where  a substring would match. 

With the change, the resulting list is something like: 
```python 

[
    "default",
    "aces_interchange",
    "cie_xyz_d65_interchange",
    "color_picking",
    "color_timing",
    "compositing_log",
    "data",
    "matte_paint",
    "scene_linear",
    "texture_paint",
    "ACES2065-1",
    "ACEScc",
    "ACEScct",
    "ACEScg",
    ...
 ]
 ```
 Fixing the issue.

## Additional review information
In our version, we have also have an additional argument called `consider_aliases=False` which adds colorspace aliases to the resulting list as  we may want to use an alias in file rules but I didn't push it as I think not everyone would like to have them added although they are valid when setting a colorspace.

Here the modified version
```python

def get_colorspace_list(colorspace_knob, node=None, consider_aliases=True):
    results = []

    # making sure any node is provided
    node = node or nuke.root()
    # unique script based identifier
    script_name = nuke.root().name()
    node_name = node.fullName()
    identifier_key = f"{script_name}_{node_name}"

    if _COLORSPACES_CACHE.get(identifier_key) is None:
        # This pattern is to match with roles which uses an indentation and
        # parentheses with original colorspace. The value returned from the
        # colorspace is the string before the indentation, so we'll need to
        # convert the values to match with value returned from the knob,
        # ei. knob.value().
        pattern = r"[\t,]+"
        for colorspace in nuke.getColorspaceList(colorspace_knob):
            colorspace_and_aliases = re.split(pattern, colorspace)
            if consinder_aliases:
                results.extend(colorspace_and_aliases)
            else:
                results.append(colorspace_and_aliases[0])

        _COLORSPACES_CACHE[identifier_key] = results

    return _COLORSPACES_CACHE[identifier_key]
    
 # Resulting list 
 [
    "default",
    "aces_interchange",
    "aces_interchange (ACES2065-1)",
    "cie_xyz_d65_interchange",
    "cie_xyz_d65_interchange (CIE-XYZ-D65)",
    "color_picking",
    "color_picking (sRGB - Texture)",
    "color_timing",
    "color_timing (ACEScct)",
    "compositing_log",
    "compositing_log (ACEScct)",
    "data",
    "data (Raw)",
    "matte_paint",
    "matte_paint (sRGB - Texture)",
    "scene_linear",
    "scene_linear (ACEScg)",
    "texture_paint",
    "texture_paint (ACEScct)",
    "ACES2065-1",
    "aces2065_1",
    "ACES - ACES2065-1",
    "lin_ap0",
    ...
 ]
    
```

## Testing notes:
1. In Nuke file rules, set a colorspace for exr's in Nuke (try multiple ones like `ACES2065-1`, `ACEScg` or `V-Log V-Gamut`) .
2. Load a published render, it should load with the colorspace set on the file rules (previously was either `default` or `scene_linear` either case was wrong.
