### PR TITLE
Fix retime gathering from Nuke (freeze frame, linear speed and TimeWarp)

### DIFF
--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -240,7 +240,7 @@ class LoadClip(plugin.NukeLoader):
                 data=data_imprint)
 
         if add_retime and version_data.get("retime"):
-            self._make_retimes(read_node, version_data)
+            self._make_retimes(read_node, version_attributes, version_data)
 
         self.set_as_member(read_node)
 
@@ -387,7 +387,7 @@ class LoadClip(plugin.NukeLoader):
             )
 
         if add_retime and version_data.get("retime"):
-            self._make_retimes(read_node, version_data)
+            self._make_retimes(read_node, version_attributes, version_data)
         else:
             self.clear_members(read_node)
 
@@ -451,7 +451,7 @@ class LoadClip(plugin.NukeLoader):
 
             read_node['frame'].setValue(str(start_frame))
 
-    def _make_retimes(self, parent_node, version_data):
+    def _make_retimes(self, parent_node, version_attributes, version_data):
         ''' Create all retime and timewarping nodes with copied animation '''
         speed = version_data.get('speed', 1)
         time_warp_nodes = version_data.get('timewarps', [])
@@ -469,14 +469,22 @@ class LoadClip(plugin.NukeLoader):
             if speed != 1:
                 rtn = nuke.createNode(
                     "Retime",
-                    "speed {}".format(speed))
+                    "speed {}".format(abs(speed))
+                )
 
                 rtn["before"].setValue("continue")
                 rtn["after"].setValue("continue")
+                rtn["reverse"].setValue(speed < 0)
+
                 rtn["input.first_lock"].setValue(True)
                 rtn["input.first"].setValue(
-                    self.script_start
+                    version_attributes["frameStart"]
                 )
+                rtn["input.last_lock"].setValue(True)
+                rtn["input.last"].setValue(
+                    version_attributes["frameEnd"]
+                )
+
                 self.set_as_member(rtn)
                 last_node = rtn
 

--- a/package.py
+++ b/package.py
@@ -6,6 +6,6 @@ client_dir = "ayon_nuke"
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">1.0.13",
+    "core": ">=1.1.0",
 }
 ayon_compatible_addons = {}

--- a/server/settings/loader_plugins.py
+++ b/server/settings/loader_plugins.py
@@ -66,7 +66,7 @@ DEFAULT_LOADER_PLUGINS_SETTINGS = {
         "representations_include": [],
         "node_name_template": "{class_name}_{ext}",
         "options_defaults": {
-            "start_at_workfile": True,
+            "start_at_workfile": False,
             "add_retime": True,
             "deep_exr": False
         }


### PR DESCRIPTION
## Changelog Description

Resolve: https://github.com/ynput/ayon-hiero/issues/12
Resolve: https://github.com/ynput/ayon-hiero/issues/29

Adjusted:
* [X] Fix linear speed gathering and freeze frames
* [X] Ensure timewarps are properly retrieved

## Additional notes
These changes needs to be tested alongside https://github.com/ynput/ayon-core/pull/1109

## Testing notes:
1. Publish plates with `speed-change (positive+negative)`, `freeze frames` and `TimeWarp` from an Editorial DCC
2. Gather published plates in `Nuke`
3. Ensure the working ranges match
