### PR TITLE
Improve selection handling in NukeWriteCreator

### DIFF
--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -360,12 +360,15 @@ class NukeWriteCreator(NukeCreator):
         Raises:
             NukeCreatorError. When the selection contains more than 1 Write node.
         """
+        if not pre_create_data.get("use_selection"):
+            return []
+
         selected_nodes = super()._get_current_selected_nodes(
             pre_create_data,
             class_name=None,
         )
 
-        if pre_create_data.get("use_selection") and not selected_nodes:
+        if not selected_nodes:
             raise NukeCreatorError("No active selection")
 
         elif len(selected_nodes) > 1:
@@ -452,6 +455,12 @@ class NukeWriteCreator(NukeCreator):
         )
 
     def create(self, product_name, instance_data, pre_create_data):
+        if not pre_create_data:
+            # add no selection for headless
+            pre_create_data = {
+                "use_selection": False
+            }
+
         # pass values from precreate to instance
         self._pass_pre_attributes_to_instance(
             instance_data,


### PR DESCRIPTION
## Changelog Description
- Added early return for no selection case.
- Simplified logic to raise error only if selected nodes are missing.
- Handled headless mode by defaulting pre_create_data when absent.


closes #56 

## Testing steps
1. have activated workfile template building templates at your project
2. have Create placeholder in template
3. build templates and see that creator placeholder is working again.