### PR TITLE
Make ocioLook loader handle multiple chained LUTs.

### DIFF
--- a/client/ayon_nuke/plugins/load/load_ociolook.py
+++ b/client/ayon_nuke/plugins/load/load_ociolook.py
@@ -180,7 +180,7 @@ class LoadOcioLookNodes(load.LoaderPlugin):
                     (
                         file for file in all_files
                         if file.endswith(extension)
-                        and lut_suffix in os.path.basename(file)
+                        and os.path.basename(file).endswith(lut_suffix)
                     ),
                     None
                 )

--- a/client/ayon_nuke/plugins/load/load_ociolook.py
+++ b/client/ayon_nuke/plugins/load/load_ociolook.py
@@ -174,11 +174,13 @@ class LoadOcioLookNodes(load.LoaderPlugin):
                 # file path from lut representation
                 extension = ocio_item["ext"]
                 item_name = ocio_item["name"]
+                lut_suffix = ocio_item.get("lut_suffix", "")
 
                 item_lut_file = next(
                     (
                         file for file in all_files
                         if file.endswith(extension)
+                        and lut_suffix in os.path.basename(file)
                     ),
                     None
                 )
@@ -192,7 +194,8 @@ class LoadOcioLookNodes(load.LoaderPlugin):
                     dir_path, item_lut_file).replace("\\", "/")
                 node["file"].setValue(item_lut_path)
                 node["name"].setValue(item_name)
-                node["direction"].setValue(ocio_item["direction"])
+                if ocio_item["direction"] == "inverse":
+                    node["invert"].setValue(True)
                 node["interpolation"].setValue(ocio_item["interpolation"])
                 node["working_space"].setValue(input_space)
 


### PR DESCRIPTION
## Changelog Description

Changes on the Nuke `ociolook` loader:
* Ensure multiple chained LUT published are properly loaded
* Fix the `invert_direction` LUT attribute for the `OCIOFileTransform` nuke node

## Additional review information
This changes would be backward compatible with `ociolook` product from previous iterations.
To test the multiple/chained LUT feature, please refer to : https://github.com/ynput/ayon-traypublisher/pull/71

## Testing notes:
1. Publish some `ociolook` product via the TrayPublisher (https://github.com/ynput/ayon-traypublisher/pull/71)
2. Load the resulting product in Nuke through the loader
