### PR TITLE
Applying correctly viewer colorspace from settings

### DIFF
--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -33,7 +33,7 @@ def get_display_and_view_colorspaces(root_node):
     """
     script_name = nuke.root().name()
     if _DISPLAY_AND_VIEW_COLORSPACES_CACHE.get(script_name) is None:
-        colorspace_knob = root_node["monitorLut"]
+        colorspace_knob = root_node["monitorOutLUT"]
         colorspaces = nuke.getColorspaceList(colorspace_knob)
         _DISPLAY_AND_VIEW_COLORSPACES_CACHE[script_name] = colorspaces
 

--- a/client/ayon_nuke/api/colorspace.py
+++ b/client/ayon_nuke/api/colorspace.py
@@ -33,6 +33,9 @@ def get_display_and_view_colorspaces(root_node):
     """
     script_name = nuke.root().name()
     if _DISPLAY_AND_VIEW_COLORSPACES_CACHE.get(script_name) is None:
+        # getting it from `monitorOutLUT` because that is the only shared
+        # display and view knob for 13 > nuke version and returns
+        # correct list of display and view colorspace profiles.
         colorspace_knob = root_node["monitorOutLUT"]
         colorspaces = nuke.getColorspaceList(colorspace_knob)
         _DISPLAY_AND_VIEW_COLORSPACES_CACHE[script_name] = colorspaces


### PR DESCRIPTION
## Changelog Description
Viewer settings is now correctly applied even for Nuke 13.2 verison. 


## Additional info
Updated the colorspace knob from "monitorLut" to "monitorOutLUT" for accurate color space fetching. This change improves the reliability of getting display and view colorspaces.

## Testing steps
1. Install Nuke 13.2
2. add the version to your application addon settings and assign it in your active applications at a project. 
3. Open the nuke and see that no popup message is not blocking the nuke session at launch. 
