### PR TITLE
AY-7442 Dissociate file_type and ext knob computation (SXR and JPG extension support).

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1142,10 +1142,27 @@ def create_write_node(
         product_name=product_name
     )
 
-    for knob in imageio_writes["knobs"]:
-        if knob["name"] == "file_type":
-            knot_type = knob["type"]
-            ext = knob[knot_type]
+    ext = None
+    knobs = imageio_writes["knobs"]
+    knob_names = {knob["name"]: knob for knob in knobs}
+
+    if "ext" in knob_names:
+        knob_type = knob_names["ext"]["type"]
+        ext = knob_names["ext"][knob_type]
+
+    # For most extensions, setting the "file_type"
+    # is enough, however sometimes they differ, e.g.:
+    # ext = sxr / file_type = exr
+    # ext = jpg / file_type = jpeg
+    elif "file_type" in knob_names:
+        knob_type = knob_names["file_type"]["type"]
+        ext = knob_names["file_type"][knob_type]
+
+    if not ext:
+        raise RuntimeError(
+            "Could not determine extension from settings"
+            f"plugin_name={plugin_name} product_name={product_name}"
+        )
 
     data.update({
         "imageio_writes": imageio_writes,

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -397,7 +397,8 @@ class NukeWriteCreator(NukeCreator):
         instance_node = created_inst.transient_data["node"]
         formatting_data = copy.deepcopy(data)
         write_node = nuke.allNodes(group=instance_node, filter="Write")[0]
-        formatting_data.update({"ext": write_node["file_type"].value()})
+        _, ext = os.path.splitext(write_node["file"].value())
+        formatting_data.update({"ext": ext[1:]})
 
         # Retieve render template and staging directory.
         fpath_template = self.temp_rendering_path_template

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -165,7 +165,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         # Determine defined file type
         path = write_node["file"].value()
         _, ext = os.path.splitext(path)
-        _, ext = ext.split(".", 1)
+        ext = ext.lstrip(".")
 
         # determine defined channel type
         color_channels = write_node["channels"].value()

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -164,8 +164,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
 
         # Determine defined file type
         path = write_node["file"].value()
-        _, ext = os.path.splitext(path)
-        ext = ext.lstrip(".")
+        ext = os.path.splitext(path)[1].lstrip(".")
 
         # determine defined channel type
         color_channels = write_node["channels"].value()

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -271,8 +271,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
 
         # Determine defined file type
         path = write_node["file"].value()
-        _, ext = os.path.splitext(path)
-        _, ext = ext.split(".", 1)
+        ext = os.path.splitext(path)[1].lstrip(".")
 
         representation = {
             "name": ext,

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -163,7 +163,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         write_node = self._write_node_helper(instance)
 
         # Determine defined file type
-        ext = write_node["file_type"].value()
+        path = write_node["file"].value()
+        _, ext = os.path.splitext(path)
+        _, ext = ext.split(".", 1)
 
         # determine defined channel type
         color_channels = write_node["channels"].value()
@@ -269,7 +271,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         output_dir = os.path.dirname(write_file_path)
 
         # Determine defined file type
-        ext = write_node["file_type"].value()
+        path = write_node["file"].value()
+        _, ext = os.path.splitext(path)
+        _, ext = ext.split(".", 1)
 
         representation = {
             "name": ext,

--- a/client/ayon_nuke/plugins/publish/extract_render_local.py
+++ b/client/ayon_nuke/plugins/publish/extract_render_local.py
@@ -89,8 +89,7 @@ class NukeRenderLocal(publish.Extractor,
 
         # Determine defined file type
         path = node["file"].value()
-        _, ext = os.path.splitext(path)
-        _, ext = ext.split(".", 1)
+        ext = os.path.splitext(path)[1].lstrip(".")
 
         colorspace = napi.get_colorspace_from_node(node)
 

--- a/client/ayon_nuke/plugins/publish/extract_render_local.py
+++ b/client/ayon_nuke/plugins/publish/extract_render_local.py
@@ -87,7 +87,11 @@ class NukeRenderLocal(publish.Extractor,
                 int(render_last_frame)
             )
 
-        ext = node["file_type"].value()
+        # Determine defined file type
+        path = node["file"].value()
+        _, ext = os.path.splitext(path)
+        _, ext = ext.split(".", 1)
+
         colorspace = napi.get_colorspace_from_node(node)
 
         if "representations" not in instance.data:

--- a/client/ayon_nuke/plugins/publish/validate_write_nodes.py
+++ b/client/ayon_nuke/plugins/publish/validate_write_nodes.py
@@ -109,7 +109,13 @@ class ValidateNukeWriteNode(
 
             key = knob_data["name"]
             values = values_by_name[key]
-            node_value = write_node[key].value()
+
+            try:
+                node_value = write_node[key].value()
+
+            except NameError:
+                self.log.warning("Missing knob %s in write node.", key)
+                continue
 
             # fix type differences
             fixed_values = []

--- a/client/ayon_nuke/startup/custom_write_node.py
+++ b/client/ayon_nuke/startup/custom_write_node.py
@@ -90,15 +90,17 @@ class WriteNodeKnobSettingPanel(nukescripts.PythonPanel):
             else:
                 knobs = node_knobs_presets
 
-        ext_knob_list = [knob for knob in knobs if knob["name"] == "file_type"]
-        if not ext_knob_list:
+        knob_names = {knob["name"]: knob for knob in knobs}
+
+        if "ext" in knob_names:
+            ext = knob_names["ext"]["value"]
+        elif "file_type" in knob_names:
+            ext = knob_names["ext"]["value"]
+        else:
             nuke.message(
-                "ERROR: No file type found in the subset's knobs."
+                "ERROR: No 'file_type' nor 'ext' found in the subset's knobs."
                 "\nPlease add one to complete setting up the node")
             return
-        else:
-            for knob in ext_knob_list:
-                ext = knob["value"]
 
         anatomy = Anatomy(get_current_project_name())
 

--- a/client/ayon_nuke/startup/custom_write_node.py
+++ b/client/ayon_nuke/startup/custom_write_node.py
@@ -98,7 +98,7 @@ class WriteNodeKnobSettingPanel(nukescripts.PythonPanel):
             ext = knob_names["ext"]["value"]
         else:
             nuke.message(
-                "ERROR: No 'file_type' nor 'ext' found in the subset's knobs."
+                "ERROR: No 'file_type' nor 'ext' found in the product's knobs."
                 "\nPlease add one to complete setting up the node")
             return
 


### PR DESCRIPTION
## Changelog Description

resolve: https://github.com/ynput/ayon-nuke/issues/69
resolve: https://github.com/ynput/ayon-nuke/issues/72

Changes to ensure SXR (exr) and JPG (jpeg) can be rendered out of our `Render` write nodes through AYON settings.

Needs to be tested with https://github.com/ynput/ayon-core/pull/1165 to ensure loader is OK.

## Additional review information

Current implementation in Nuke assumes that `file_type` and output file extension are always matching.
However Nuke has some disperencies here:
* file extension: jpg / file_type: jpeg
* file extension: sxr / file_type: exr

These changes ensure extension is set from an `ext` knob if defined, then computed from the `path` knob.

## Testing notes:

Render SXR output:
1. Set `Render (write)` node knobs settings (`ayon+settings://nuke/imageio/nodes/required_nodes/0/knobs`) to:
    * `file_type` : exr (Text)
    * `ext`: sxr (Text)

Render JPG output:
1. Set `Render (write)` node knobs settings (`ayon+settings://nuke/imageio/nodes/required_nodes/0/knobs`) to:
    * `file_type` : jpeg (Text)
    * `ext`: jpg (Text)
    
2. Create a new `Render` product
3. Publisher the `Render` product
4. Ensure the `sxr` or `jpg` representation if properly published
