### PR TITLE
AY-7442 Prepare logic and settings to handle stereo reviewable.

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -114,6 +114,26 @@ class BakingStreamFilterModel(BaseSettingsModel):
         default_factory=list, title="Product names")
 
 
+class StereoNodes(BaseSettingsModel):
+    node_class: str = SettingsField(title="Node class")
+    knobs: list[KnobModel] = SettingsField(
+        default_factory=list,
+        title="Node knobs")
+
+
+class StereoNodesConfigModel(BaseSettingsModel):
+    """Only multiview (stereo) nodes supported.
+
+    You can add multiple nodes and set their knobs.
+    Order of nodes is important.
+    """
+    enabled: bool = SettingsField(False)
+    stereo_nodes: list[StereoNodes] = SettingsField(
+        default_factory=list,
+        title="Stereo knobs"
+    )
+
+
 class ReformatNodesRepositionNodes(BaseSettingsModel):
     node_class: str = SettingsField(title="Node class")
     knobs: list[KnobModel] = SettingsField(
@@ -159,6 +179,9 @@ class IntermediateOutputModel(BaseSettingsModel):
         title="Bake viewer input process node (LUT)",
         section="Baking additional",
     )
+    stereo_nodes_config: StereoNodesConfigModel = SettingsField(
+        default_factory=StereoNodesConfigModel,
+        title="Stereo Nodes")
     reformat_nodes_config: ReformatNodesConfigModel = SettingsField(
         default_factory=ReformatNodesConfigModel,
         title="Reformat Nodes")
@@ -377,6 +400,15 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
                 },
                 "bake_viewer_process": True,
                 "bake_viewer_input_process": True,
+                "stereo_nodes_config": {
+                    "enabled": False,
+                    "stereo_nodes": [
+                        {
+                            "node_class": "Anaglyph",
+                            "knobs": []
+                        }
+                    ]
+                },
                 "reformat_nodes_config": {
                     "enabled": False,
                     "reposition_nodes": [


### PR DESCRIPTION
## Changelog Description

This draft PR aims to prepare support for stereo review.

Changes:
* Rework `extract_review_intermediates` to make it handle multi-views input and new settings
* Added new server settings to be able to inject an `Anaglyph` node

![image](https://github.com/user-attachments/assets/fffa7ebf-8429-4016-83f1-19ed6348bb29)


## Additional review information

Keeping this one as draft as this is premilinary work to support stereo review feature.

## Testing notes:
1. Package and upload this as new package
2. Ensure the newly added `ayon+settings://nuke/publish/ExtractReviewIntermediates/outputs/0/stereo_nodes_config` attribute is enabled
3. Setup your Nuke script to make it render SXR (you can follow  https://github.com/ynput/ayon-nuke/pull/81)
4. Publish a `sxr` render product with review enabled
5. Ensure the process goes through and that reviewable media is OK using the `Anaglyph` node
