### PR TITLE
Add custom node classes and change subset to product

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -678,8 +678,11 @@ def get_imageio_node_setting(node_class, plugin_name, product_name):
     imageio_node = None
     for node in required_nodes:
         log.info(node)
+        node_class_preset = node["nuke_node_class"]
+        if node.get("custom_class"):
+            node_class_preset = node["custom_class"]
         if (
-            node_class in node["nuke_node_class"]
+            node_class in node_class_preset
             and plugin_name in node["plugins"]
         ):
             imageio_node = node
@@ -709,7 +712,13 @@ def get_imageio_node_override_setting(
     # find matching override node
     override_imageio_node = None
     for onode in override_nodes:
-        if node_class not in onode["nuke_node_class"]:
+
+        node_class_preset = onode["nuke_node_class"]
+
+        if onode.get("custom_class"):
+            node_class_preset = onode["custom_class"]
+
+        if node_class not in node_class_preset:
             continue
 
         if plugin_name not in onode["plugins"]:
@@ -717,10 +726,10 @@ def get_imageio_node_override_setting(
 
         # TODO change 'subsets' to 'product_names' in settings
         if (
-            onode["subsets"]
+            onode["products"]
             and not any(
                 re.search(s.lower(), product_name.lower())
-                for s in onode["subsets"]
+                for s in onode["products"]
             )
         ):
             continue

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -677,7 +677,6 @@ def get_imageio_node_setting(node_class, plugin_name, product_name):
 
     imageio_node = None
     for node in required_nodes:
-        log.info(node)
         node_class_preset = node["nuke_node_class"]
         if node.get("custom_class"):
             node_class_preset = node["custom_class"]
@@ -724,12 +723,13 @@ def get_imageio_node_override_setting(
         if plugin_name not in onode["plugins"]:
             continue
 
-        # TODO change 'subsets' to 'product_names' in settings
+        products = onode.get("subsets", onode.get("products", []))
+
         if (
-            onode["products"]
+            products
             and not any(
                 re.search(s.lower(), product_name.lower())
-                for s in onode["products"]
+                for s in products
             )
         ):
             continue

--- a/client/ayon_nuke/startup/custom_write_node.py
+++ b/client/ayon_nuke/startup/custom_write_node.py
@@ -128,7 +128,6 @@ class WriteNodeKnobSettingPanel(nukescripts.PythonPanel):
         preset_names = []
         knobs_nodes = []
 
-
         settings = [
             node_settings for node_settings
             in get_nuke_imageio_settings()["nodes"]["override_nodes"]
@@ -136,7 +135,8 @@ class WriteNodeKnobSettingPanel(nukescripts.PythonPanel):
                     node_settings["nuke_node_class"] == "Write" or
                     node_settings["custom_class"] == "Write"
                )
-            and node_settings["subsets"]
+            and node_settings.get(
+                "subsets", node_settings.get("products", []))
         ]
         if not settings:
             return [], []
@@ -146,10 +146,9 @@ class WriteNodeKnobSettingPanel(nukescripts.PythonPanel):
                 knobs_nodes = settings[i]["knobs"]
 
         for setting in settings:
-            # TODO change 'subsets' to 'product_names' in settings
-            for product_name in setting["subsets"]:
-                preset_names.append(product_name)
-
+            # TODO: (antirotor) deprecate "products" in favor of "subsets"
+            products = setting.get("subsets", setting.get("products", []))
+            preset_names.extend(iter(products))
         return preset_names, knobs_nodes
 
 

--- a/client/ayon_nuke/startup/custom_write_node.py
+++ b/client/ayon_nuke/startup/custom_write_node.py
@@ -127,10 +127,15 @@ class WriteNodeKnobSettingPanel(nukescripts.PythonPanel):
     def get_node_knobs_setting(self, selected_preset=None):
         preset_names = []
         knobs_nodes = []
+
+
         settings = [
             node_settings for node_settings
             in get_nuke_imageio_settings()["nodes"]["override_nodes"]
-            if node_settings["nuke_node_class"] == "Write"
+            if (
+                    node_settings["nuke_node_class"] == "Write" or
+                    node_settings["custom_class"] == "Write"
+               )
             and node_settings["subsets"]
         ]
         if not settings:

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -47,6 +47,11 @@ class NodesModel(BaseSettingsModel):
         title="Nuke Node Class",
         enum_resolver=nuke_node_class_enum
     )
+    custom_class: str = SettingsField(
+        default_factory="",
+        title="Custom Node Class",
+        description="Custom node class not listed above (optional)"
+    )
 
 
 class RequiredNodesModel(NodesModel):
@@ -63,9 +68,9 @@ class RequiredNodesModel(NodesModel):
 
 
 class OverrideNodesModel(NodesModel):
-    subsets: list[str] = SettingsField(
+    products: list[str] = SettingsField(
         default_factory=list,
-        title="Subsets"
+        title="Products"
     )
 
     knobs: list[KnobModel] = SettingsField(
@@ -309,6 +314,7 @@ DEFAULT_IMAGEIO_SETTINGS = {
             {
                 "plugins": ["CreateWriteRender"],
                 "nuke_node_class": "Write",
+                "custom_class": "",
                 "knobs": [
                     {"type": "text", "name": "file_type", "text": "exr"},
                     {"type": "text", "name": "datatype", "text": "16 bit half"},
@@ -327,6 +333,7 @@ DEFAULT_IMAGEIO_SETTINGS = {
             {
                 "plugins": ["CreateWritePrerender"],
                 "nuke_node_class": "Write",
+                "custom_class": "",
                 "knobs": [
                     {"type": "text", "name": "file_type", "text": "exr"},
                     {"type": "text", "name": "datatype", "text": "16 bit half"},
@@ -345,6 +352,7 @@ DEFAULT_IMAGEIO_SETTINGS = {
             {
                 "plugins": ["CreateWriteImage"],
                 "nuke_node_class": "Write",
+                "custom_class": "",
                 "knobs": [
                     {"type": "text", "name": "file_type", "text": "tiff"},
                     {"type": "text", "name": "datatype", "text": "16 bit"},

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -32,7 +32,8 @@ def nuke_node_class_enum():
         {"value": "Camera4", "label": "Camera [3D]"},
         {"value": "Camera2", "label": "Camera [3D Classic]"},
         {"value": "Scene", "label": "Scene [3D Classic]"},
-        {"value": "BackdropNode", "label": "Backdrop [Other]"}, 
+        {"value": "BackdropNode", "label": "Backdrop [Other]"},
+        {"value": "custom_class", "label": "Custom Class"},
     ]
 
 
@@ -45,7 +46,8 @@ class NodesModel(BaseSettingsModel):
     )
     nuke_node_class: str = SettingsField(
         title="Nuke Node Class",
-        enum_resolver=nuke_node_class_enum
+        enum_resolver=nuke_node_class_enum,
+        conditionalEnum=True,
     )
     custom_class: str = SettingsField(
         default_factory="",


### PR DESCRIPTION
## Changelog Description
Re-adding possibility to to specify custom node classes in node overrides. #43 turned node classes to enum but that removed ability to specify any other class than those listed there. Also changed usage of "subset" to "product" as mentioned in #70

## Testing notes:
1. Create new override `ayon+settings://nuke/imageio/nodes/override_nodes` targeting node class not listed in the **Nuke Node Class** enum.
2. See if the override was applied


Closes #70
Closes #84 
Closes #26 


[AY-5776](https://app.clickup.com/t/6658547/AY-5776)