### PR TITLE
add settings conversion for #85

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -724,7 +724,7 @@ def get_imageio_node_override_setting(
         if plugin_name not in onode["plugins"]:
             continue
 
-        # TODO change 'subsets' to 'product_names' in settings
+
         if (
             onode["products"]
             and not any(

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -723,13 +723,13 @@ def get_imageio_node_override_setting(
         if plugin_name not in onode["plugins"]:
             continue
 
-        products = onode.get("subsets", onode.get("products", []))
+        product_names = onode["product_names"]
 
         if (
-            products
+            product_names
             and not any(
                 re.search(s.lower(), product_name.lower())
-                for s in products
+                for s in product_names
             )
         ):
             continue

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -678,8 +678,11 @@ def get_imageio_node_setting(node_class, plugin_name, product_name):
     imageio_node = None
     for node in required_nodes:
         log.info(node)
+        node_class_preset = node["nuke_node_class"]
+        if node.get("custom_class"):
+            node_class_preset = node["custom_class"]
         if (
-            node_class in node["nuke_node_class"]
+            node_class in node_class_preset
             and plugin_name in node["plugins"]
         ):
             imageio_node = node
@@ -709,7 +712,13 @@ def get_imageio_node_override_setting(
     # find matching override node
     override_imageio_node = None
     for onode in override_nodes:
-        if node_class not in onode["nuke_node_class"]:
+
+        node_class_preset = onode["nuke_node_class"]
+
+        if onode.get("custom_class"):
+            node_class_preset = onode["custom_class"]
+
+        if node_class not in node_class_preset:
             continue
 
         if plugin_name not in onode["plugins"]:
@@ -717,10 +726,10 @@ def get_imageio_node_override_setting(
 
         # TODO change 'subsets' to 'product_names' in settings
         if (
-            onode["subsets"]
+            onode["products"]
             and not any(
                 re.search(s.lower(), product_name.lower())
-                for s in onode["subsets"]
+                for s in onode["products"]
             )
         ):
             continue

--- a/client/ayon_nuke/startup/custom_write_node.py
+++ b/client/ayon_nuke/startup/custom_write_node.py
@@ -135,20 +135,18 @@ class WriteNodeKnobSettingPanel(nukescripts.PythonPanel):
                     node_settings["nuke_node_class"] == "Write" or
                     node_settings["custom_class"] == "Write"
                )
-            and node_settings.get(
-                "subsets", node_settings.get("products", []))
+            and node_settings.get("product_names", [])
         ]
         if not settings:
             return [], []
 
         for i, _ in enumerate(settings):
-            if selected_preset in settings[i]["subsets"]:
+            if selected_preset in settings[i]["product_names"]:
                 knobs_nodes = settings[i]["knobs"]
 
         for setting in settings:
-            # TODO: (antirotor) deprecate "products" in favor of "subsets"
-            products = setting.get("subsets", setting.get("products", []))
-            preset_names.extend(iter(products))
+            product_names = setting.get("product_names", [])
+            preset_names.extend(iter(product_names))
         return preset_names, knobs_nodes
 
 

--- a/client/ayon_nuke/startup/custom_write_node.py
+++ b/client/ayon_nuke/startup/custom_write_node.py
@@ -127,10 +127,15 @@ class WriteNodeKnobSettingPanel(nukescripts.PythonPanel):
     def get_node_knobs_setting(self, selected_preset=None):
         preset_names = []
         knobs_nodes = []
+
+
         settings = [
             node_settings for node_settings
             in get_nuke_imageio_settings()["nodes"]["override_nodes"]
-            if node_settings["nuke_node_class"] == "Write"
+            if (
+                    node_settings["nuke_node_class"] == "Write" or
+                    node_settings["custom_class"] == "Write"
+               )
             and node_settings["subsets"]
         ]
         if not settings:

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -180,13 +180,19 @@ def _convert_imageio_subsets_0_3_2(overrides: dict) -> None:
     if "nodes" not in imageio_overrides:
         return
 
-    if "override_nodes" not in imageio_overrides["nodes"]:
-        return
+    if "required_nodes" in imageio_overrides["nodes"]:
+        for node in imageio_overrides["nodes"]["required_nodes"]:
+            if "custom_class" not in node:
+                node["custom_class"] = ""
 
-    for node in imageio_overrides["nodes"]["override_nodes"]:
-        if "subsets" in node:
-            node["products"] = node.pop("subsets")
-            logger.debug(f"Converted 'subsets' to 'products' for node: {node}")
+    if "override_nodes" in imageio_overrides["nodes"]:
+        for node in imageio_overrides["nodes"]["override_nodes"]:
+            if "subsets" in node:
+                node["products"] = node.pop("subsets")
+                logger.debug(
+                    f"Converted 'subsets' to 'products' for node: {node}")
+            if "custom_class" not in node:
+                node["custom_class"] = ""
 
 
 def _convert_publish_plugins(overrides):

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any
 from copy import deepcopy
+from ayon_server.logging import logger
 
 
 def _get_viewer_config_from_string(input_string):
@@ -169,6 +170,25 @@ def _convert_gizmo_menu_0_3_1(overrides):
     overrides["gizmo"] = new_gizmos          
 
 
+def _convert_imageio_subsets_0_3_2(overrides: dict) -> None:
+    """Convert subsets key to products."""
+    if "imageio" not in overrides:
+        return
+
+    imageio_overrides = overrides["imageio"]
+
+    if "nodes" not in imageio_overrides:
+        return
+
+    if "override_nodes" not in imageio_overrides["nodes"]:
+        return
+
+    for node in imageio_overrides["nodes"]["override_nodes"]:
+        if "subsets" in node:
+            node["products"] = node.pop("subsets")
+            logger.debug(f"Converted 'subsets' to 'products' for node: {node}")
+
+
 def _convert_publish_plugins(overrides):
     if "publish" not in overrides:
         return
@@ -182,4 +202,5 @@ def convert_settings_overrides(
     _convert_gizmo_menu_0_3_1(overrides)
     _convert_imageio_configs_0_2_3(overrides)
     _convert_publish_plugins(overrides)
+    _convert_imageio_subsets_0_3_2(overrides)
     return overrides

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -171,7 +171,7 @@ def _convert_gizmo_menu_0_3_1(overrides):
 
 
 def _convert_imageio_subsets_0_3_2(overrides: dict) -> None:
-    """Convert subsets key to products."""
+    """Convert subsets key to product_names."""
     if "imageio" not in overrides:
         return
 
@@ -188,9 +188,9 @@ def _convert_imageio_subsets_0_3_2(overrides: dict) -> None:
     if "override_nodes" in imageio_overrides["nodes"]:
         for node in imageio_overrides["nodes"]["override_nodes"]:
             if "subsets" in node:
-                node["products"] = node.pop("subsets")
+                node["product_names"] = node.pop("subsets")
                 logger.debug(
-                    f"Converted 'subsets' to 'products' for node: {node}")
+                    f"Converted 'subsets' to 'product_names' for node: {node}")
             if "custom_class" not in node:
                 node["custom_class"] = ""
 

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -70,9 +70,9 @@ class RequiredNodesModel(NodesModel):
 
 
 class OverrideNodesModel(NodesModel):
-    products: list[str] = SettingsField(
+    product_names: list[str] = SettingsField(
         default_factory=list,
-        title="Products"
+        title="Product names"
     )
 
     knobs: list[KnobModel] = SettingsField(

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -47,6 +47,11 @@ class NodesModel(BaseSettingsModel):
         title="Nuke Node Class",
         enum_resolver=nuke_node_class_enum
     )
+    custom_class: str = SettingsField(
+        default_factory="",
+        title="Custom Node Class",
+        description="Custom node class not listed above (optional)"
+    )
 
 
 class RequiredNodesModel(NodesModel):
@@ -63,9 +68,9 @@ class RequiredNodesModel(NodesModel):
 
 
 class OverrideNodesModel(NodesModel):
-    subsets: list[str] = SettingsField(
+    products: list[str] = SettingsField(
         default_factory=list,
-        title="Subsets"
+        title="Products"
     )
 
     knobs: list[KnobModel] = SettingsField(
@@ -309,6 +314,7 @@ DEFAULT_IMAGEIO_SETTINGS = {
             {
                 "plugins": ["CreateWriteRender"],
                 "nuke_node_class": "Write",
+                "custom_class": "",
                 "knobs": [
                     {"type": "text", "name": "file_type", "text": "exr"},
                     {"type": "text", "name": "datatype", "text": "16 bit half"},
@@ -327,6 +333,7 @@ DEFAULT_IMAGEIO_SETTINGS = {
             {
                 "plugins": ["CreateWritePrerender"],
                 "nuke_node_class": "Write",
+                "custom_class": "",
                 "knobs": [
                     {"type": "text", "name": "file_type", "text": "exr"},
                     {"type": "text", "name": "datatype", "text": "16 bit half"},
@@ -345,6 +352,7 @@ DEFAULT_IMAGEIO_SETTINGS = {
             {
                 "plugins": ["CreateWriteImage"],
                 "nuke_node_class": "Write",
+                "custom_class": "",
                 "knobs": [
                     {"type": "text", "name": "file_type", "text": "tiff"},
                     {"type": "text", "name": "datatype", "text": "16 bit"},

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -50,7 +50,7 @@ class NodesModel(BaseSettingsModel):
         conditionalEnum=True,
     )
     custom_class: str = SettingsField(
-        default_factory="",
+        default="",
         title="Custom Node Class",
         description="Custom node class not listed above (optional)"
     )


### PR DESCRIPTION
## Changelog Description
#85 was merged before settings conversion could be added. This is adding conversion function that converts `subsets` to `product_names` so project overrides can be copyied.

## Testing notes:
1. Create project overrides in older ayon-nuke addons on `ayon+settings://nuke/imageio/nodes/override_nodes`. Add something to *subsets*
2. Switch to this ayon-nuke version
3. Copy project overrides from previous version
