### PR TITLE
Allow Camera instance on any version of `Camera` node class

### DIFF
--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -186,10 +186,19 @@ class NukeCreator(NewCreator):
             selected_nodes = nuke.allNodes()
 
         if class_name:
+            # Allow class name implicit last versions of class names like
+            # `Camera` to match any of its explicit versions, e.g.
+            # `Camera3` or `Camera4`.
+            if not class_name[-1].isdigit():
+                # Match name with any digit
+                pattern = rf"{class_name}\d*"
+            else:
+                pattern = class_name
+            regex = re.compile(pattern)
             selected_nodes = [
                 node
                 for node in selected_nodes
-                if node.Class() == class_name
+                if regex.match(node.Class())
             ]
 
         if class_name and use_selection and not selected_nodes:

--- a/client/ayon_nuke/plugins/create/create_camera.py
+++ b/client/ayon_nuke/plugins/create/create_camera.py
@@ -20,7 +20,7 @@ class CreateCamera(NukeCreator):
 
     # plugin attributes
     node_color = "0xff9100ff"
-    node_class_name = "Camera3"
+    node_class_name = "Camera"
 
     def create_instance_node(
         self,


### PR DESCRIPTION
## Changelog Description

Allow Camera instance on any version of `Camera` node class

## Additional review information

Fix #86 

## Testing notes:
1. Creating camera instance should be allowed on any `Camera` class version, including `Camera4`, `Camera2`, `Camera`, etc.