### PR TITLE
Fix: remove unnecessary logger import

### DIFF
--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -1,7 +1,6 @@
 import re
 from typing import Any
 from copy import deepcopy
-from ayon_server.logging import logger
 
 
 def _get_viewer_config_from_string(input_string):
@@ -189,8 +188,6 @@ def _convert_imageio_subsets_0_3_2(overrides: dict) -> None:
         for node in imageio_overrides["nodes"]["override_nodes"]:
             if "subsets" in node:
                 node["product_names"] = node.pop("subsets")
-                logger.debug(
-                    f"Converted 'subsets' to 'product_names' for node: {node}")
             if "custom_class" not in node:
                 node["custom_class"] = ""
 


### PR DESCRIPTION
## Changelog Description
PR #88 introduced debug log to conversion function utilizing logger from server backend. This unfortunately created dependency to new server version just because of this.  This PR is removing this import so it stays as much compatible as possible with older versions.

## Testing notes:
Addon shouldn't fail on older (but declared compatible) version of the server
