### PR TITLE
Allow loading any `.nk` file with `LoadBackdropNodes`

### DIFF
--- a/client/ayon_nuke/plugins/load/load_backdrop.py
+++ b/client/ayon_nuke/plugins/load/load_backdrop.py
@@ -19,9 +19,9 @@ from ayon_nuke.api import containerise, update_container
 
 
 class LoadBackdropNodes(load.LoaderPlugin):
-    """Loading Published Backdrop nodes (workfile, nukenodes)"""
+    """Loading published .nk files to backdrop nodes"""
 
-    product_types = {"workfile", "nukenodes"}
+    product_types = {"*"}
     representations = {"*"}
     extensions = {"nk"}
 


### PR DESCRIPTION
## Changelog Description

Allow loading any `.nk` file with `LoadBackdropNodes`

## Additional review information

Not sure if there's reason to do this or not - but it came up recently that matte shapes from e.g. Silhouette couldn't be loaded otherwise. Didn't test whether this is the valid approach to loading that data however.

## Testing notes:

1. Importing other `.nk` products makes sense?
2. Importing should work.
