### PR TITLE
Remove some legacy terminology in codebase

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2117,9 +2117,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
             )
 
     def set_context_settings(self):
-        # replace reset resolution from avalon core to pype's
         self.reset_resolution()
-        # replace reset resolution from avalon core to pype's
         self.reset_frame_range_handles()
         # add colorspace menu item
         self.set_colorspace()
@@ -2169,7 +2167,7 @@ def get_write_node_template_attr(node):
         "create_write_prerender": "CreateWritePrerender",
         "create_write_render": "CreateWriteRender"
     }
-    # get avalon data from node
+    # get AYON data from node
     node_data = get_node_data(node, INSTANCE_DATA_KNOB)
     identifier = node_data["creator_identifier"]
 
@@ -2739,7 +2737,7 @@ def node_tempfile():
     """
 
     tmp_file = tempfile.NamedTemporaryFile(
-        mode="w", prefix="openpype_nuke_temp_", suffix=".nk", delete=False
+        mode="w", prefix="AYON_nuke_temp_", suffix=".nk", delete=False
     )
     tmp_file.close()
     node_tempfile_path = tmp_file.name

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -500,7 +500,7 @@ def get_avalon_knob_data(node, prefix="avalon:", create=True):
 
     Arguments:
         node (obj): Nuke node to search for data,
-        prefix (str, optional): filtering prefix
+        prefix (str | list[str]): filtering prefix
 
     Returns:
         data (dict)
@@ -540,7 +540,10 @@ def add_write_node(name, file_path, knobs, **kwarg):
 
     Arguments:
         name (str): nuke node name
-        kwarg (attrs): data for nuke knobs
+        file_path (str): file path to write
+        knobs (list[dict]): nuke knobs to be set from settings
+        kwarg (dict): formatting attributes data for nuke knobs,
+            must at least include `frame_range` key.
 
     Returns:
         node (obj): nuke write node

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -419,7 +419,7 @@ def containerise(node,
     """
     data = OrderedDict(
         [
-            ("schema", "openpype:container-2.0"),
+            ("schema", "ayon:container-3.0"),
             ("id", AVALON_CONTAINER_ID),
             ("name", name),
             ("namespace", namespace),

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -55,7 +55,7 @@ from .colorspace import (
 
 
 def _collect_and_cache_nodes(creator):
-    key = "openpype.nuke.nodes"
+    key = "ayon.nuke.nodes"
     if key not in creator.collection_shared_data:
         instances_by_identifier = defaultdict(list)
         for item in list_instances():
@@ -1281,7 +1281,7 @@ def convert_to_valid_instaces():
     # save into new workfile
     current_file = workio.current_file()
 
-    # add file suffex if not
+    # add file suffix if not
     if "_publisherConvert" not in current_file:
         new_workfile = (
             current_file[:-3]
@@ -1392,8 +1392,8 @@ def convert_to_valid_instaces():
 def _remove_old_knobs(node):
     remove_knobs = [
         "review", "publish", "render", "suspend_publish", "warn", "divd",
-        "OpenpypeDataGroup", "OpenpypeDataGroup_End", "deadlinePriority",
-        "deadlineChunkSize", "deadlineConcurrentTasks", "Deadline"
+        "deadlinePriority", "deadlineChunkSize", "deadlineConcurrentTasks",
+        "Deadline"
     ]
 
     # remove all old knobs

--- a/client/ayon_nuke/plugins/load/load_effects.py
+++ b/client/ayon_nuke/plugins/load/load_effects.py
@@ -62,7 +62,7 @@ class LoadEffects(load.LoaderPlugin):
             "colorspaceInput": colorspace,
         }
 
-        # add additional metadata from the version to imprint to Avalon knob
+        # add additional metadata from the version to imprint to AYON knob
         for k in [
             "frameStart",
             "frameEnd",

--- a/client/ayon_nuke/plugins/load/load_effects_ip.py
+++ b/client/ayon_nuke/plugins/load/load_effects_ip.py
@@ -64,7 +64,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
             "version": version_entity["version"],
             "colorspaceInput": colorspace,
         }
-        # add additional metadata from the version to imprint to Avalon knob
+        # add additional metadata from the version to imprint to AYON knob
         for k in [
             "frameStart",
             "frameEnd",

--- a/client/ayon_nuke/plugins/load/load_script_precomp.py
+++ b/client/ayon_nuke/plugins/load/load_script_precomp.py
@@ -78,7 +78,7 @@ class LinkAsGroup(load.LoaderPlugin):
         P["useOutput"].setValue(True)
 
         with P:
-            # iterate through all nodes in group node and find pype writes
+            # iterate through all nodes in group node and find AYON writes
             writes = [n.name() for n in nuke.allNodes()
                       if n.Class() == "Group"
                       if get_avalon_knob_data(n)]

--- a/client/ayon_nuke/plugins/publish/collect_headless_farm.py
+++ b/client/ayon_nuke/plugins/publish/collect_headless_farm.py
@@ -20,7 +20,7 @@ class CollectRenderOnFarm(pyblish.api.ContextPlugin):
             return
 
         for instance in context:
-            if instance.data["family"] == "workfile":
+            if instance.data["productType"] == "workfile":
                 instance.data["active"] = False
                 continue
 


### PR DESCRIPTION
## Changelog Description

Remove some avalon/openpype references in codebase.

## Additional review information

The biggest remainder still is the deprecated `get_avalon_knob_data` and `set_avalon_knob_data` which seem to be non-trivial to refactor to the `set_node_data` replacement so I didn't bother for now. Probably better left for someone more knowledgeable in Nuke.

## Testing notes:

1. Proofread
