### PR TITLE
Chore: Don't use deprecated workfile method

### DIFF
--- a/client/ayon_nuke/api/push_to_project.py
+++ b/client/ayon_nuke/api/push_to_project.py
@@ -72,7 +72,7 @@ def main():
     )
     # Save current workfile.
     current_file = host.get_current_workfile()
-    host.save_file(current_file)
+    host.save_workfile(current_file)
 
     for container in host.ls():
         bake_container(container)
@@ -110,7 +110,7 @@ def main():
     # Save current workfile to new context.
     pushed_workfile = os.path.join(
         workdir, os.path.basename(current_file))
-    host.save_file(pushed_workfile)
+    host.save_workfile(pushed_workfile)
 
     # Open current context workfile.
     host.open_workfile(current_file)

--- a/client/ayon_nuke/api/push_to_project.py
+++ b/client/ayon_nuke/api/push_to_project.py
@@ -113,6 +113,6 @@ def main():
     host.save_file(pushed_workfile)
 
     # Open current context workfile.
-    host.open_file(current_file)
+    host.open_workfile(current_file)
 
     nuke.message(f"Pushed to project: \n{pushed_workfile}")

--- a/client/ayon_nuke/api/push_to_project.py
+++ b/client/ayon_nuke/api/push_to_project.py
@@ -71,7 +71,7 @@ def main():
         project_settings=project_settings
     )
     # Save current workfile.
-    current_file = host.current_file()
+    current_file = host.get_current_workfile()
     host.save_file(current_file)
 
     for container in host.ls():

--- a/client/ayon_nuke/plugins/publish/extract_headless_farm.py
+++ b/client/ayon_nuke/plugins/publish/extract_headless_farm.py
@@ -24,7 +24,7 @@ class ExtractRenderOnFarm(pyblish.api.InstancePlugin):
         host = registered_host()
         current_datetime = datetime.now()
         formatted_timestamp = current_datetime.strftime("%Y%m%d%H%M%S")
-        base, ext = os.path.splitext(host.current_file())
+        base, ext = os.path.splitext(host.get_current_workfile())
 
         directory = os.path.join(os.path.dirname(base), "farm_submissions")
         if not os.path.exists(directory):
@@ -35,4 +35,4 @@ class ExtractRenderOnFarm(pyblish.api.InstancePlugin):
         )
         path = os.path.join(directory, filename).replace("\\", "/")
         instance.context.data["currentFile"] = path
-        shutil.copy(host.current_file(), path)
+        shutil.copy(host.get_current_workfile(), path)


### PR DESCRIPTION
## Changelog Description
Use `get_current_workfile` instead of `current_workfile`, `open_workfile` instead of `open_file` and `save_workfile` instead of `save_file`.

## Additional review information
Method `current_workfile` is deprecated for years now.

## Testing notes:
Not sure how to test changed places.
