### PR TITLE
Fix/writes version sync

### DIFF
--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -161,6 +161,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         )
 
         write_node = self._write_node_helper(instance)
+        if instance.data.get("stagingDir_is_custom", False):
+            self.log.info("Custom staging dir detected. Syncing write nodes output path.")
+            napi.lib.writes_version_sync(write_node, self.log)
 
         # Determine defined file type
         path = write_node["file"].value()

--- a/client/ayon_nuke/plugins/publish/increment_write_node.py
+++ b/client/ayon_nuke/plugins/publish/increment_write_node.py
@@ -9,62 +9,6 @@ from ayon_core.pipeline import OptionalPyblishPluginMixin
 from ayon_nuke.api.lib import writes_version_sync
 
 
-def _process_writes_sync(publish_item, instance):
-    if not publish_item.is_active(instance.data):
-        return
-
-    if not instance.data.get("stagingDir_is_custom"):
-        publish_item.log.info(
-            f"'{instance}' instance doesn't have custom staging dir."
-        )
-        return
-
-    write_node = instance.data["transientData"].get("writeNode")
-    if write_node is None:
-        group_node = instance.data["transientData"]["node"]
-        publish_item.log.info(
-            f"Instance '{group_node.name()}' is missing write node!"
-        )
-        return
-
-    render_target = instance.data["render_target"]
-    if render_target in ["frames", "frames_farm"]:
-        publish_item.log.info(
-            "Instance reuses existing frames, not updating path"
-        )
-        return
-
-    writes_version_sync(write_node, publish_item.log)
-    nuke.scriptSave()
-
-
-class IncrementWriteNodePathPreSubmit(
-    pyblish.api.InstancePlugin, OptionalPyblishPluginMixin
-):
-    """Increments render path in write node with actual workfile version
-    before potential farm submission.
-
-    This allows to send multiple publishes to DL (for all of them Publish part
-    suspended) that wouldn't overwrite `renders` subfolders.
-
-    Ignores artist hardcoded paths and `frames`, eg `Use existing frames` where
-    path should stay put.
-
-    """
-
-    order = pyblish.api.IntegratorOrder
-    label = "Update path in Write node - Pre Submit"
-    hosts = ["nuke", "nukeassist"]
-    families = ["render", "prerender", "image"]
-
-    settings_category = "nuke"
-    optional = True
-    active = True
-
-    def process(self, instance):
-        _process_writes_sync(self, instance)
-
-
 class IncrementWriteNodePathPostSubmit(
     pyblish.api.InstancePlugin, OptionalPyblishPluginMixin
 ):
@@ -85,4 +29,29 @@ class IncrementWriteNodePathPostSubmit(
     active = True
 
     def process(self, instance):
-        _process_writes_sync(self, instance)
+        if not self.is_active(instance.data):
+            return
+
+        if not instance.data.get("stagingDir_is_custom"):
+            self.log.info(
+                f"'{instance}' instance doesn't have custom staging dir."
+            )
+            return
+
+        write_node = instance.data["transientData"].get("writeNode")
+        if write_node is None:
+            group_node = instance.data["transientData"]["node"]
+            self.log.info(
+                f"Instance '{group_node.name()}' is missing write node!"
+            )
+            return
+
+        render_target = instance.data["render_target"]
+        if render_target in ["frames", "frames_farm"]:
+            self.log.info(
+                "Instance reuses existing frames, not updating path"
+            )
+            return
+
+        writes_version_sync(write_node, self.log)
+        nuke.scriptSave()


### PR DESCRIPTION
adresses https://github.com/ynput/ayon-nuke/issues/118

## Changelog Description
- calls `writes_version_sync` during collection to account for manually incrementing workfiles
- removes redundant `wites_version_sync` call at validation
