### PR TITLE
Fix wrong frame being integrated as slate frame

### DIFF
--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -1,4 +1,5 @@
 import os
+import re
 import nuke
 
 import pyblish.api
@@ -310,6 +311,22 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             "{{:0{}d}}".format(len(str(last_frame)))
         ).format(first_frame)
 
+    def _get_frame_start_index(self, collected_frames, frame_start):
+        """Get index of *frame_start* within *collected_frames*.
+
+        Args:
+            collected_frames (list): collected frames.
+            frame_start (str): initial frame of the sequence.
+
+        Returns:
+            int: index of the initial frame in **collected_frames**.
+
+        """
+        pattern = rf"\b{frame_start}\b"
+        for index, file_name in enumerate(collected_frames):
+            if re.search(pattern, file_name):
+                return index
+
     def _add_slate_frame_to_collected_frames(
         self,
         instance,
@@ -341,8 +358,10 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
                 first_frame - 1,
                 last_frame
             )
-
-            slate_frame = collected_frames[0].replace(
+            frame_start_index = self._get_frame_start_index(
+                collected_frames, frame_start_str
+            )
+            slate_frame = collected_frames[frame_start_index].replace(
                 frame_start_str, frame_slate_str)
             collected_frames.insert(0, slate_frame)
 


### PR DESCRIPTION
[Here](https://github.com/ynput/ayon-nuke/issues/123) the related issue.

## Changelog Description

Issue comes from the following line: 

```
           slate_frame = collected_frames[0].replace(
                frame_start_str, frame_slate_str)
```

Since `collected_frames` was not sorted, the first element (`collected_frames[0]`) does not match the value of `frame_start_str` (which in our case corresponds to 1001). Therefore, replacing that value did not work and the following line `collected_frames.insert(0, slate_frame)` introduced whichever element is at `collected_frames[0]`. 

For instance, in our test, the first element was frame 1017 and `collected_frames` ended up being like this: 
```
COLLECTED FRAMES -> ['renderScanCheckMain.1017.exr', 'renderScanCheckMain.1017.exr', 'renderScanCheckMain.1051.exr',  ... ]
```

We now look for `frame_start_str` inside `collected_frames`, get its index and use it in the replace function.

## Additional review information

Another possible fix would be just to sort `collected_frames` (change [this](https://github.com/ynput/ayon-nuke/blob/develop/client/ayon_nuke/plugins/publish/collect_writes.py#L408) line to `return sorted(collected_frames)` but I think it would be more consistent to look for the index and replace rather than assuming again index 0 is the frame start. 

## Testing notes:
1. Launch Nuke.
2. Generate exrs (with a slate frame)
3. Publish using `use existing frames - farm` option. 

Slate node should be integrated correctly.
closes https://github.com/ynput/ayon-nuke/issues/123