### PR TITLE
AY-7997_Extract Render Local: Raise `PublishError` on render failure

### DIFF
--- a/client/ayon_nuke/plugins/publish/extract_render_local.py
+++ b/client/ayon_nuke/plugins/publish/extract_render_local.py
@@ -81,11 +81,19 @@ class NukeRenderLocal(publish.Extractor,
             self.log.info("End frame: {}".format(render_last_frame))
 
             # Render frames
-            nuke.execute(
-                str(node_product_name),
-                int(render_first_frame),
-                int(render_last_frame)
-            )
+            try:
+                nuke.execute(
+                    str(node_product_name),
+                    int(render_first_frame),
+                    int(render_last_frame)
+                )
+            except RuntimeError as exc:
+                raise publish.PublishError(
+                    title="Render Failed",
+                    message=f"Failed to render {node_product_name}",
+                    description="Check Nuke console for more information.",
+                    detail=str(exc),
+                ) from exc
 
         # Determine defined file type
         path = node["file"].value()


### PR DESCRIPTION
## Changelog Description

Extract Render Local: Raise `PublishError` on render failure to execute the node for rendering so that more meaningful hint is given in publisher UI.

## Additional review information

closes https://github.com/ynput/ayon-nuke/issues/126
[AY-7997](https://app.clickup.com/t/86c4amk6c)

## Testing notes:

1. Set up a node graph where Writer render would fail (e.g. have failing Reader as input)
2. The publisher UI should show a more meaningful error message with some more information.
