### PR TITLE
Create Backdrop: Remove `maintain_selection` attribute.

### DIFF
--- a/client/ayon_nuke/plugins/create/create_backdrop.py
+++ b/client/ayon_nuke/plugins/create/create_backdrop.py
@@ -16,7 +16,6 @@ class CreateBackdrop(NukeCreator):
     label = "Nukenodes (backdrop)"
     product_type = "nukenodes"
     icon = "file-archive-o"
-    maintain_selection = True
 
     # plugin attributes
     node_color = "0xdfea5dff"


### PR DESCRIPTION
## Changelog Description

Remove `maintain_selection` attribute. It does nothing.

## Additional review information

This attribute only existed due to inheriting it from the legacy creators before switching to the new publisher (where it used to go through code like [this](https://github.com/ynput/ayon-core/blob/c2f3d8b114ecd93871029144bc81a77ad841758e/client/ayon_core/pipeline/create/legacy_create.py#L208)). However, I am pretty sure now it's unused.

Equivalent to:
- https://github.com/ynput/ayon-blender/pull/138
- https://github.com/ynput/ayon-houdini/pull/282

## Testing notes:

1. Creator should not be affected.
