### PR TITLE
Load: Handles on version can be unset

### DIFF
--- a/client/ayon_nuke/plugins/load/actions.py
+++ b/client/ayon_nuke/plugins/load/actions.py
@@ -71,7 +71,7 @@ class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
             return
 
         # Include handles
-        start -= version_attributes.get("handleStart", 0)
-        end += version_attributes.get("handleEnd", 0)
+        start -= version_attributes.get("handleStart") or 0
+        end += version_attributes.get("handleEnd") or 0
 
         lib.update_frame_range(start, end)

--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -129,8 +129,8 @@ class LoadClip(plugin.NukeLoader):
         self.log.debug(
             "Representation id `{}` ".format(repre_id))
 
-        self.handle_start = version_attributes.get("handleStart", 0)
-        self.handle_end = version_attributes.get("handleEnd", 0)
+        self.handle_start = version_attributes.get("handleStart") or 0
+        self.handle_end = version_attributes.get("handleEnd") or 0
 
         first = version_attributes.get("frameStart")
         last = version_attributes.get("frameEnd")
@@ -311,8 +311,8 @@ class LoadClip(plugin.NukeLoader):
 
         repre_id = repre_entity["id"]
 
-        self.handle_start = version_attributes.get("handleStart", 0)
-        self.handle_end = version_attributes.get("handleEnd", 0)
+        self.handle_start = version_attributes.get("handleStart") or 0
+        self.handle_end = version_attributes.get("handleEnd") or 0
 
         first = version_attributes.get("frameStart")
         last = version_attributes.get("frameEnd")


### PR DESCRIPTION
## Changelog Description
Alllow `handleStart` and `handleEnd` to be `None` on version.

## Additional review information
Attributes `handleStart` and `handleEnd` are always filled but can be filled with `None`. The handling method `get` would be working only if the attribute would not be available on version. The change works for both `None` and `0`.

## Testing notes:
1. Plates without filled `handleStart` or `handleEnd` filled on version can be loaded.
