### PR TITLE
Chore: Allow per project addon version

### DIFF
--- a/package.py
+++ b/package.py
@@ -3,6 +3,7 @@ title = "Nuke"
 version = "0.3.9+dev"
 app_host_name = "nuke"
 client_dir = "ayon_nuke"
+project_can_override_addon_version = True
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {


### PR DESCRIPTION
## Changelog Description
Addon can be used in per-project bundles.

## Additional informatio
I didn't find any conflicts that would not allow to use the addon in per project bundles.

## Testing notes:
1. Addon can be used in per-project bundles.
