### PR TITLE
Support Mandatory Workfiles

### DIFF
--- a/client/ayon_nuke/plugins/create/workfile_creator.py
+++ b/client/ayon_nuke/plugins/create/workfile_creator.py
@@ -15,6 +15,7 @@ import nuke
 class WorkfileCreator(AutoCreator):
 
     settings_category = "nuke"
+    is_mandatory = False
 
     identifier = "workfile"
     product_type = "workfile"
@@ -65,6 +66,8 @@ class WorkfileCreator(AutoCreator):
         instance = CreatedInstance(
             self.product_type, product_name, instance_data, self
         )
+        if hasattr(instance, "set_mandatory"):
+            instance.set_mandatory(self.is_mandatory)
         instance.transient_data["node"] = root_node
         self._add_instance_to_context(instance)
 

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -203,6 +203,17 @@ class CreateWriteImageModel(BaseSettingsModel):
         return value
 
 
+class CreateWorkfileModel(BaseSettingsModel):
+    is_mandatory: bool = SettingsField(
+        default=False,
+        title="Mandatory workfile",
+        description=(
+            "Workfile cannot be disabled by user in UI."
+            " Requires core addon 1.4.1 or newer."
+        )
+    )
+
+
 class CreatorPluginsSettings(BaseSettingsModel):
     CreateWriteRender: CreateWriteRenderModel = SettingsField(
         default_factory=CreateWriteRenderModel,
@@ -215,6 +226,10 @@ class CreatorPluginsSettings(BaseSettingsModel):
     CreateWriteImage: CreateWriteImageModel = SettingsField(
         default_factory=CreateWriteImageModel,
         title="Create Write Image"
+    )
+    WorkfileCreator: CreateWorkfileModel = SettingsField(
+        default_factory=CreateWorkfileModel,
+        title="Create Workfile"
     )
 
 


### PR DESCRIPTION
## Changelog Description
This supports marking workfiles as mandatory in order to restrict users from disabling workfile publishes.

## Additional review information
Depends on this PR here:
https://github.com/ynput/ayon-core/pull/1360

Adapted from this PR:
https://github.com/ynput/ayon-maya/pull/312

⚠️ this requires you to build/upload the addon to your AYON instance as server settings get changed.

## Testing notes:
1. build/upload the addon
2. enable manadatory workfiles via `ayon+settings://nuke/create/WorkfileCreator/is_mandatory`
3. check that the Workfile Toggle is gone from the Publisher
