### PR TITLE
imprint containers with `project_name`

### DIFF
--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -425,6 +425,7 @@ def containerise(node,
             ("namespace", namespace),
             ("loader", str(loader)),
             ("representation", context["representation"]["id"]),
+            ("project_name", context["project"]["name"]),
         ],
 
         **data or dict()


### PR DESCRIPTION
## Changelog Description
This PR is a small patch for persisting `project_name` info on loaded containers.

## Additional review information
Origin of this was the following use case.
IT needs to un-archive `projectA` in order for artists to continue some shots as a new project `projectB`.
TD copy/pastes existing workfiles to the new project. AYON Manager can't render loaded products since they've never been imprinted with the corresponding `project_name`.

> 📝 This will not automatically fix existing containers in workfiles but only executes on newly loaded products.

## Testing notes:
1. open a random nuke workfile
2. locate loaded container in your script
3. check that `project_name` is *not* available on the AYON node tab
4. reload the container
5. check that `project_name` *is now* available on the AYON node tab