### PR TITLE
Load: Added actions to lock and unlock container versions

### DIFF
--- a/client/ayon_nuke/plugins/inventory/lock_version.py
+++ b/client/ayon_nuke/plugins/inventory/lock_version.py
@@ -22,6 +22,7 @@ class LockVersions(InventoryAction):
             container["version_locked"] = True
             imprint(node, {"avalon:version_locked": True})
             node["avalon:version_locked"].setLabel("Version locked")
+        return True
 
 
 class UnlockVersions(InventoryAction):
@@ -45,3 +46,4 @@ class UnlockVersions(InventoryAction):
             container["version_locked"] = False
             imprint(node, {"avalon:version_locked": False})
             node["avalon:version_locked"].setLabel("Version locked")
+        return True


### PR DESCRIPTION
## Changelog Description
Implement inventory actions to be able to lock/unlock version of a container.

## Additional review information
The PR is related to https://github.com/ynput/ayon-core/pull/1447 which adds the option to lock and unload version of a container.

Added 2 actions to lock and unlock the version by settings `"version_locked"` on the knobs.

## Testing notes:
1. Make sure to use both PRs (if not merged yet).
2. Launch Nuke.
3. Load something to scene that is not from latest version.
4. Open scene manager.
5. Select the container and run `Actions > Lock version` on the container.
6. Validation of outdated containers (e.g. during publishing) should not raise an error.