### PR TITLE
Refactors Nuke instance data collection

### DIFF
--- a/client/ayon_nuke/plugins/publish/collect_nuke_instance_data.py
+++ b/client/ayon_nuke/plugins/publish/collect_nuke_instance_data.py
@@ -2,19 +2,19 @@ import nuke
 import pyblish.api
 
 
-class CollectInstanceData(pyblish.api.InstancePlugin):
+class CollectNukeInstanceData(pyblish.api.InstancePlugin):
     """Collect Nuke instance data
 
     """
 
-    order = pyblish.api.CollectorOrder - 0.49
+    order = pyblish.api.CollectorOrder + 0.001
     label = "Collect Nuke Instance Data"
     hosts = ["nuke", "nukeassist"]
 
     settings_category = "nuke"
 
     # presets
-    sync_workfile_version_on_families = []
+    sync_workfile_version_on_product_types = []
 
     def process(self, instance):
         product_type = instance.data["productType"]
@@ -27,7 +27,7 @@ class CollectInstanceData(pyblish.api.InstancePlugin):
         pixel_aspect = format_.pixelAspect()
 
         # sync workfile version
-        if product_type in self.sync_workfile_version_on_families:
+        if product_type in self.sync_workfile_version_on_product_types:
             self.log.debug(
                 "Syncing version with workfile for '{}'".format(
                     product_type

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -73,7 +73,7 @@ class NodeModel(BaseSettingsModel):
         return value
 
 
-class CollectInstanceDataModel(BaseSettingsModel):
+class CollectNukeInstanceDataModel(BaseSettingsModel):
     sync_workfile_version_on_product_types: list[str] = SettingsField(
         default_factory=list,
         enum_resolver=nuke_product_types_enum,
@@ -246,9 +246,9 @@ class ExtractSlateFrameModel(BaseSettingsModel):
 
 
 class PublishPluginsModel(BaseSettingsModel):
-    CollectInstanceData: CollectInstanceDataModel = SettingsField(
+    CollectNukeInstanceData: CollectNukeInstanceDataModel = SettingsField(
         title="Collect Instance Version",
-        default_factory=CollectInstanceDataModel,
+        default_factory=CollectNukeInstanceDataModel,
         section="Collectors"
     )
     ValidateCorrectAssetContext: OptionalPluginModel = SettingsField(
@@ -318,14 +318,13 @@ class PublishPluginsModel(BaseSettingsModel):
 
 
 DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
-    "CollectInstanceData": {
+    "CollectNukeInstanceData": {
         "sync_workfile_version_on_product_types": [
             "nukenodes",
             "camera",
             "gizmo",
             "source",
             "render",
-            "write"
         ]
     },
     "ValidateCorrectAssetContext": {


### PR DESCRIPTION
## Changelog Description

The `CollectInstanceData` plugin and its corresponding settings model have been renamed to `CollectNukeInstanceData` for better clarity and specificity within the Nuke context. This renaming ensures that the plugin's purpose is immediately apparent, reducing ambiguity and improving the overall maintainability of the codebase.

The plugin's execution order has been adjusted to ensure that instance data is collected at the appropriate time. This adjustment helps prevent potential issues related to data dependencies and ensures that all necessary information is available when the plugin is executed.

Finally, the `sync_workfile_version_on_families` setting has been renamed to `sync_workfile_version_on_product_types` for a more semantically correct representation of its function.

## Additional info
Settings change do not have backward compatibility check, because it was broken anyway for some time. 

## Testing notes:
1. Ensure that the Nuke instance data is collected correctly after the renaming and refactoring.
2. Verify that the plugin execution order does not introduce any data dependency issues.
3. Confirm that the `sync_workfile_version_on_product_types` setting functions as expected.

closes https://github.com/ynput/ayon-nuke/issues/111