### PR TITLE
Applies plugin settings to Nuke creators

### DIFF
--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -529,9 +529,12 @@ class NukeWriteCreator(NukeCreator):
 
     def apply_settings(self, project_settings):
         """Method called on initialization of plugin to apply settings."""
-
-        # plugin settings
+        # plugin settings for particular creator
         plugin_settings = self.get_creator_settings(project_settings)
+        # enabled
+        self.enabled = plugin_settings.get("enabled")
+        # order
+        self.order = plugin_settings.get("order")
         temp_rendering_path_template = (
             plugin_settings.get("temp_rendering_path_template")
             or self.temp_rendering_path_template

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -94,6 +94,16 @@ class PrenodeModel(BaseSettingsModel):
 
 
 class CreateWriteRenderModel(BaseSettingsModel):
+    enabled: bool = SettingsField(
+        True,
+        title="Enabled",
+        description="Enable or disable the plugin"
+    )
+    order: int = SettingsField(
+        100,
+        title="Order",
+        description="Order of the plugin in the list"
+    )
     temp_rendering_path_template: str = SettingsField(
         title="Temporary rendering path template"
     )
@@ -131,6 +141,16 @@ class CreateWriteRenderModel(BaseSettingsModel):
 
 
 class CreateWritePrerenderModel(BaseSettingsModel):
+    enabled: bool = SettingsField(
+        True,
+        title="Enabled",
+        description="Enable or disable the plugin"
+    )
+    order: int = SettingsField(
+        100,
+        title="Order",
+        description="Order of the plugin in the list"
+    )
     temp_rendering_path_template: str = SettingsField(
         title="Temporary rendering path template"
     )
@@ -168,6 +188,16 @@ class CreateWritePrerenderModel(BaseSettingsModel):
 
 
 class CreateWriteImageModel(BaseSettingsModel):
+    enabled: bool = SettingsField(
+        True,
+        title="Enabled",
+        description="Enable or disable the plugin"
+    )
+    order: int = SettingsField(
+        100,
+        title="Order",
+        description="Order of the plugin in the list"
+    )
     temp_rendering_path_template: str = SettingsField(
         title="Temporary rendering path template"
     )
@@ -213,19 +243,51 @@ class CreateWorkfileModel(BaseSettingsModel):
         )
     )
 
+class DefaultPluginModel(BaseSettingsModel):
+    enabled: bool = SettingsField(
+        True,
+        title="Enabled",
+        description="Enable or disable the plugin"
+    )
+    order: int = SettingsField(
+        100,
+        title="Order",
+        description="Order of the plugin in the list"
+    )
+
 
 class CreatorPluginsSettings(BaseSettingsModel):
     CreateWriteRender: CreateWriteRenderModel = SettingsField(
         default_factory=CreateWriteRenderModel,
-        title="Create Write Render"
+        title="Render (write)"
     )
     CreateWritePrerender: CreateWritePrerenderModel = SettingsField(
         default_factory=CreateWritePrerenderModel,
-        title="Create Write Prerender"
+        title="Prerender (write)"
     )
     CreateWriteImage: CreateWriteImageModel = SettingsField(
         default_factory=CreateWriteImageModel,
-        title="Create Write Image"
+        title="Image (write)"
+    )
+    CreateBackdrop: DefaultPluginModel = SettingsField(
+        default_factory=DefaultPluginModel,
+        title="Nukenodes (backdrop)"
+    )
+    CreateCamera: DefaultPluginModel = SettingsField(
+        default_factory=DefaultPluginModel,
+        title="Camera (3d)"
+    )
+    CreateGizmo: DefaultPluginModel = SettingsField(
+        default_factory=DefaultPluginModel,
+        title="Gizmo (group)"
+    )
+    CreateModel: DefaultPluginModel = SettingsField(
+        default_factory=DefaultPluginModel,
+        title="Model (3d)"
+    )
+    CreateSource: DefaultPluginModel = SettingsField(
+        default_factory=DefaultPluginModel,
+        title="Source (read)"
     )
     WorkfileCreator: CreateWorkfileModel = SettingsField(
         default_factory=CreateWorkfileModel,
@@ -235,6 +297,8 @@ class CreatorPluginsSettings(BaseSettingsModel):
 
 DEFAULT_CREATE_SETTINGS = {
     "CreateWriteRender": {
+        "enabled": True,
+        "order": 100,
         "temp_rendering_path_template": "{work}/renders/nuke/{product[name]}/{product[name]}.{frame}.{ext}",
         "default_variants": [
             "Main",
@@ -267,6 +331,8 @@ DEFAULT_CREATE_SETTINGS = {
         ]
     },
     "CreateWritePrerender": {
+        "enabled": True,
+        "order": 100,
         "temp_rendering_path_template": "{work}/renders/nuke/{product[name]}/{product[name]}.{frame}.{ext}",
         "default_variants": [
             "Key01",
@@ -284,6 +350,8 @@ DEFAULT_CREATE_SETTINGS = {
         "prenodes": []
     },
     "CreateWriteImage": {
+        "enabled": True,
+        "order": 100,
         "temp_rendering_path_template": "{work}/renders/nuke/{product[name]}/{product[name]}.{ext}",
         "default_variants": [
             "StillFrame",
@@ -309,5 +377,25 @@ DEFAULT_CREATE_SETTINGS = {
                 ]
             }
         ]
-    }
+    },
+    "CreateBackdrop": {
+        "enabled": True,
+        "order": 100,
+    },
+    "CreateCamera": {
+        "enabled": True,
+        "order": 100,
+    },
+    "CreateGizmo": {
+        "enabled": True,
+        "order": 100,
+    },
+    "CreateModel": {
+        "enabled": True,
+        "order": 100,
+    },
+    "CreateSource": {
+        "enabled": True,
+        "order": 100,
+    },
 }


### PR DESCRIPTION
## Changelog Description

The NukeWriteCreator class now respects the `enabled` and `order` settings defined in the project settings. This allows administrators to selectively enable or disable creators, as well as adjust their order in the user interface, without modifying the core code.

## Additional info

The `apply_settings` method in the `NukeWriteCreator` class has been modified to retrieve the `enabled` and `order` settings from the project settings. These values are then assigned to the corresponding attributes of the creator instance.

## Testing notes:
1. Verify that the 'enabled' setting in the project settings correctly enables or disables the creator.
2. Check that the 'order' setting in the project settings affects the order in which the creator appears in the UI.

Relates to YN-0086