### PR TITLE
Fix add_gizmo_path passed value

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2618,7 +2618,7 @@ def add_scripts_gizmo():
                 path = StringTemplate.format_template(path, template_data)
                 gizmo_paths_to_add.append(path)
             if gizmo_paths_to_add:
-                toolbar_menu.add_gizmo_path(path)
+                toolbar_menu.add_gizmo_path(gizmo_paths_to_add)
         elif option == "gizmo_definition":
             for gizmo in gizmos:
                 for gizmo_item in gizmo["sub_gizmo_list"]:


### PR DESCRIPTION
## Changelog Description
Fixes issue with log `*** WRN: >>> { ayon_nuke.api.gizmo_menu }: [ This path doesn't exist: p ] `

## Additional review information
`add_gizmo_path` expects list, it passed string instead.

## Testing notes:
1. start Nuke
2. check log inside if log is still present
