### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_nuke/plugins/create/create_backdrop.py
+++ b/client/ayon_nuke/plugins/create/create_backdrop.py
@@ -15,6 +15,7 @@ class CreateBackdrop(NukeCreator):
     identifier = "create_backdrop"
     label = "Nukenodes (backdrop)"
     product_type = "nukenodes"
+    product_base_type = "nukenodes"
     icon = "file-archive-o"
 
     # plugin attributes

--- a/client/ayon_nuke/plugins/create/create_camera.py
+++ b/client/ayon_nuke/plugins/create/create_camera.py
@@ -16,6 +16,7 @@ class CreateCamera(NukeCreator):
     identifier = "create_camera"
     label = "Camera (3d)"
     product_type = "camera"
+    product_base_type = "camera"
     icon = "camera"
 
     # plugin attributes

--- a/client/ayon_nuke/plugins/create/create_gizmo.py
+++ b/client/ayon_nuke/plugins/create/create_gizmo.py
@@ -14,6 +14,7 @@ class CreateGizmo(NukeCreator):
     identifier = "create_gizmo"
     label = "Gizmo (group)"
     product_type = "gizmo"
+    product_base_type = "gizmo"
     icon = "file-archive-o"
     default_variants = ["ViewerInput", "Lut", "Effect"]
 

--- a/client/ayon_nuke/plugins/create/create_model.py
+++ b/client/ayon_nuke/plugins/create/create_model.py
@@ -14,6 +14,7 @@ class CreateModel(NukeCreator):
     identifier = "create_model"
     label = "Model (3d)"
     product_type = "model"
+    product_base_type = "model'"
     icon = "cube"
     default_variants = ["Main"]
 

--- a/client/ayon_nuke/plugins/create/create_source.py
+++ b/client/ayon_nuke/plugins/create/create_source.py
@@ -17,6 +17,7 @@ class CreateSource(NukeCreator):
     identifier = "create_source"
     label = "Source (read)"
     product_type = "source"
+    product_base_type = "source"
     icon = "film"
     default_variants = ["Effect", "Backplate", "Fire", "Smoke"]
 

--- a/client/ayon_nuke/plugins/create/create_write_image.py
+++ b/client/ayon_nuke/plugins/create/create_write_image.py
@@ -14,6 +14,7 @@ class CreateWriteImage(napi.NukeWriteCreator):
     identifier = "create_write_image"
     label = "Image (write)"
     product_type = "image"
+    product_base_type = "image"
     icon = "sign-out"
 
     instance_attributes = [

--- a/client/ayon_nuke/plugins/create/create_write_prerender.py
+++ b/client/ayon_nuke/plugins/create/create_write_prerender.py
@@ -10,6 +10,7 @@ class CreateWritePrerender(napi.NukeWriteCreator):
     identifier = "create_write_prerender"
     label = "Prerender (write)"
     product_type = "prerender"
+    product_base_type = "prerender"
     icon = "sign-out"
 
     instance_attributes = [

--- a/client/ayon_nuke/plugins/create/create_write_render.py
+++ b/client/ayon_nuke/plugins/create/create_write_render.py
@@ -10,6 +10,7 @@ class CreateWriteRender(napi.NukeWriteCreator):
     identifier = "create_write_render"
     label = "Render (write)"
     product_type = "render"
+    product_base_type = "render"
     icon = "sign-out"
 
     instance_attributes = [

--- a/client/ayon_nuke/plugins/create/workfile_creator.py
+++ b/client/ayon_nuke/plugins/create/workfile_creator.py
@@ -17,6 +17,7 @@ class WorkfileCreator(AutoCreator):
 
     identifier = "workfile"
     product_type = "workfile"
+    product_base_type = "workfile"
 
     default_variant = "Main"
 


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.