### PR TITLE
fix: remove ' from product_base_type

### DIFF
--- a/client/ayon_nuke/plugins/create/create_model.py
+++ b/client/ayon_nuke/plugins/create/create_model.py
@@ -14,7 +14,7 @@ class CreateModel(NukeCreator):
     identifier = "create_model"
     label = "Model (3d)"
     product_type = "model"
-    product_base_type = "model'"
+    product_base_type = "model"
     icon = "cube"
     default_variants = ["Main"]
 


### PR DESCRIPTION
## Changelog Description
Removed an additional `'` on the `product_base_type` value

Error Message:
```
        },
        "folderId": "80d77490b98811f09b870a1e7b16a38b",
        "productBaseType": "model'"
    }
}
Detail: Invalid data provided: 1 validation error for ProductPostModel
productBaseType
  string does not match regex "^[a-zA-Z0-9_]([a-zA-Z0-9_\.\-]*[a-zA-Z0-9_])?$" (type=value_error.str.regex; pattern=^[a-zA-Z0-9_]([a-zA-Z0-9_\.\-]*[a-zA-Z0-9_])?$).
 ```


