### PR TITLE
Load Clip: handling missing frameStart/frameEnd version attribute 

### DIFF
--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -152,10 +152,6 @@ class LoadClip(plugin.NukeLoader):
         # but file sequences its the first frame that is 1 frame lower.
         slate_frames = repre_entity["data"].get("slateFrames", 0)
         extension = "." + repre_entity["context"]["ext"]
-
-        if extension in VIDEO_EXTENSIONS:
-        slate_frames = repre_entity["data"].get("slateFrames", 0)
-        extension = "." + repre_entity["context"]["ext"]
         files_count = len(repre_entity["files"])
 
         if first is not None and last is not None:


### PR DESCRIPTION
## Changelog Description
This PR is to ensure the frameStart/frameEnd version attributes should be handle in Clip loader when they are missing. With this PR, the TypeError contributes to these missing attributes would be resolved.

Resolve https://github.com/ynput/ayon-nuke/issues/162

## Additional review information
n/a

## Testing notes:
1. Launch Nuke
2. Load Clip and Setting Version of it.
