### PR TITLE
YN-0489: Load Clip: Fix load slate frame logic with NoneType + int error

### DIFF
--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -143,11 +143,6 @@ class LoadClip(plugin.NukeLoader):
             version_attributes, handle_start, handle_end
         )
 
-        if first is not None and last is not None and not is_sequence:
-            duration = last - first
-            first = 1
-            last = first + duration
-
         # If a slate is present, the frame range is 1 frame longer for movies,
         # but file sequences its the first frame that is 1 frame lower.
         slate_frames = repre_entity["data"].get("slateFrames", 0)
@@ -159,17 +154,10 @@ class LoadClip(plugin.NukeLoader):
                 duration = last - first
                 first = 1
                 last = first + duration
-
-            # If a slate is present, the frame range is 1 frame longer for movies,
-            # but file sequences its the first frame that is 1 frame lower.
             if extension in VIDEO_EXTENSIONS:
                 last += slate_frames
             elif extension in IMAGE_EXTENSIONS and files_count != 1:
                 first -= slate_frames
-
-        files_count = len(repre_entity["files"])
-        if extension in IMAGE_EXTENSIONS and files_count != 1:
-            first -= slate_frames
 
         # Fallback to folder name when namespace is None
         if namespace is None:
@@ -204,7 +192,7 @@ class LoadClip(plugin.NukeLoader):
                     read_node, first, last, start_at_workfile, slate_frames
                 )
             else:
-                first, last = self._set_range_to_node_by_nuke(
+                self._set_range_to_node_by_nuke(
                     read_node, filepath, start_at_workfile, slate_frames
                 )
 


### PR DESCRIPTION
## Changelog Description

Remove duplicate logic + remove unused variable assignment

## Additional review information

Got broken with: https://github.com/ynput/ayon-nuke/pull/176
Fix https://github.com/ynput/ayon-nuke/issues/191

## Testing notes:

1. Load clip should work with e.g. maya renders
2. Load clip should work with EXR render published via tray publisher (see issue description)
3. Load clip should work with video file published via tray publisher

If a slate frame is applied to the loaded product - the loaded video file should still be set correctly in the frame range/timeline.