### PR TITLE
fix: use actual node name if the desired name was already taken

### DIFF
--- a/client/ayon_nuke/plugins/load/load_camera.py
+++ b/client/ayon_nuke/plugins/load/load_camera.py
@@ -64,15 +64,19 @@ class AlembicCameraLoader(load.LoaderPlugin):
                     "Camera3",
                     "name {} file {} read_from_file True".format(
                         object_name, file),
-                    inpanel=False
+                    inpanel=False,
                 )
             except RuntimeError: # older nuke version
                 camera_node = nuke.createNode(
                     "Camera2",
                     "name {} file {} read_from_file True".format(
                         object_name, file),
-                    inpanel=False
-                )                
+                    inpanel=False,
+                )
+
+            # get the actual name of the camera node
+            # might be different if a the desired name is already in use
+            object_name = camera_node.name()
 
             camera_node.forceValidate()
             camera_node["frame_rate"].setValue(float(fps))


### PR DESCRIPTION
## Changelog Description
Avoid moving the wrong camera node on import

## Additional review information
When the desired node name was already taken, the new node would get auto renamed (eg.: `my_camera1` )
This PR makes sure we use whichever name the node ends up getting

## Testing notes:
1. import a camera (or create a node with the exact name the camera would have)
2. move to it some random place in the network
3. import the same camera again
4. node imported in step 1 should NOT move