### PR TITLE
Fix #205 - Scene Inventory not finding Ayon Loaders/Read Nodes inside group nodes

### DIFF
--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -540,7 +540,7 @@ def ls():
     need to implement a for-loop that then *yields* one Container at
     a time.
     """
-    all_nodes = nuke.allNodes(recurseGroups=False)
+    all_nodes = nuke.allNodes(recurseGroups=True)
 
     nodes = [n for n in all_nodes]
 


### PR DESCRIPTION
## Changelog Description
Set the recurseGroups = True to enable the manage window to find read nodes/ayon loaders inside of group nodes. 

Fix https://github.com/ynput/ayon-nuke/issues/205
