### PR TITLE
Fix for being able to load in effects published from hiero in nuke again

### DIFF
--- a/client/ayon_nuke/plugins/load/load_effects.py
+++ b/client/ayon_nuke/plugins/load/load_effects.py
@@ -8,8 +8,8 @@ from ayon_nuke.api import plugin
 class LoadEffects(plugin.NukeGroupLoader):
     """Loading colorspace soft effect exported from nukestudio"""
 
-    product_base_types = {"effect"}
-    product_types = product_base_types
+    product_base_types = {"effect", "plate"}
+    product_types = {"effect"}
     representations = {"*"}
     extensions = {"json"}
 


### PR DESCRIPTION
## Changelog Description
added plate in the product_base_type again otherwise you can't load in the effects


<img width="852" height="566" alt="image" src="https://github.com/user-attachments/assets/c0f63351-17fe-4a2f-bb9f-2b8b1d771ba9" />