### PR TITLE
pass all user knobs to placeholder_data

### DIFF
--- a/client/ayon_nuke/api/workfile_template_builder.py
+++ b/client/ayon_nuke/api/workfile_template_builder.py
@@ -1,4 +1,5 @@
 import collections
+from typing import Any
 import nuke
 
 from ayon_core.pipeline import registered_host
@@ -17,6 +18,13 @@ from .lib import (
 )
 
 PLACEHOLDER_SET = "PLACEHOLDERS_SET"
+
+# this value is taken from `pythonextensions/site-packages/hiero/core/FnNukeHelpers.py` line 266
+# based on the official documentation: https://docs.nuke.com/nuke/knobs/knob-flags
+# this knob is supposed to be used for internal use only, and not exposed in the
+# regular api. We shold probably find a better way to do this.
+NODE_KNOB = 0x200000
+"""FLag for knobs that are used to control a nodes dag appearance."""
 
 
 class NukeTemplateBuilder(AbstractTemplateBuilder):
@@ -92,14 +100,21 @@ class NukePlaceholderPlugin(PlaceholderPlugin):
         node = nuke.toNode(placeholder_item.scene_identifier)
         imprint(node, placeholder_data)
 
-    def _parse_placeholder_node_data(self, node):
-        placeholder_data = {}
+    def _parse_placeholder_node_data(self, node: nuke.Node):
+        placeholder_data: dict[str, Any] = {}
+
+        # make sure all expected keys are present
         for key in self.get_placeholder_keys():
-            knob = node.knob(key)
-            value = None
-            if knob is not None:
-                value = knob.getValue()
-            placeholder_data[key] = value
+            placeholder_data[key] = None
+
+        # read all user knobs
+        for knob in node.knobs().values():
+            # skip internal knobs
+            if knob.getFlag(NODE_KNOB):
+                continue
+
+            placeholder_data[knob.name()] = knob.getValue()
+
         return placeholder_data
 
     def delete_placeholder(self, placeholder):


### PR DESCRIPTION
## Changelog Description
reads passes all knobs to `placeholder_data` to allow for better backwards compatibility 

## Additional review information


## Testing notes:
1. get an old placeholder node that uses `product type` and a new one (I pasted 2 example nodes here)
2. (optional) run the attached python script to confirm that old values are still supported
3. run "build workfile from template" and check if both get recognised 


## Example Nodes
```
set cut_paste_input [stack 0]
version 15.2 v7
push $cut_paste_input
NoOp {
 name NEW_PLACEHOLDER
 tile_color 0xff0000ff
 selected true
 xpos -299
 ypos -167
 addUserKnob {20 User}
 addUserKnob {1 builder_type l Builder_type}
 builder_type context_folder
 addUserKnob {1 link_type l Link_type}
 link_type template
 addUserKnob {1 product_base_type l Product_base_type}
 product_base_type plate
 addUserKnob {1 representation l Representation}
 representation exr
 addUserKnob {1 loader l Loader}
 loader LoadClip
 addUserKnob {1 loader_args l Loader_args}
 addUserKnob {3 order l Order}
 addUserKnob {1 folder_path l Folder_path}
 addUserKnob {1 product_name l Product_name}
 addUserKnob {1 plugin_identifier l Plugin_identifier}
 plugin_identifier nuke.load
 addUserKnob {6 is_placeholder l Is_placeholder +HIDDEN +STARTLINE}
 is_placeholder true
}
NoOp {
 inputs 0
 name OLD_PLACEHOLDER
 tile_color 0xff0000ff
 selected true
 xpos -300
 ypos -236
 addUserKnob {20 User}
 addUserKnob {1 builder_type l Builder_type}
 builder_type context_folder
 addUserKnob {1 product_type l Product_type}
 product_type plate
 addUserKnob {1 representation l Representation}
 representation exr
 addUserKnob {1 loader l Loader}
 loader LoadClip
 addUserKnob {1 loader_args l Loader_args}
 addUserKnob {3 order l Order}
 addUserKnob {1 folder_path l Folder_path}
 addUserKnob {1 product_name l Product_name}
 product_name .*plateL02.*
 addUserKnob {1 plugin_identifier l Plugin_identifier}
 plugin_identifier nuke.load
 addUserKnob {6 is_placeholder l Is_placeholder +HIDDEN +STARTLINE}
 is_placeholder true
}

```

## Test Script
```py
from ayon_core.pipeline import registered_host
from ayon_nuke.api import workfile_template_builder


host = registered_host()
builder = workfile_template_builder.NukeTemplateBuilder(host)


for placeholder in builder.get_placeholders():
    print(placeholder)
    for k in ["product_base_type", "product_type", "family"]:
        print(f"\t {k}",  placeholder.data.get(k, "NOT SET"))
```

expected output
```
< LoadPlaceholderItem NEW_PLACEHOLDER >
	 product_base_type plate
	 product_type NOT SET
	 family NOT SET
< LoadPlaceholderItem OLD_PLACEHOLDER >
	 product_base_type None
	 product_type plate
	 family NOT SET
```


