### PR TITLE
fix: include "LEGACY_PLACEHOLDER_KEYS" in _parse_placeholder_node_data

### DIFF
--- a/client/ayon_nuke/api/workfile_template_builder.py
+++ b/client/ayon_nuke/api/workfile_template_builder.py
@@ -22,6 +22,7 @@ PLACEHOLDER_SET = "PLACEHOLDERS_SET"
 
 LEGACY_PLACEHOLDER_KEYS = {
     "product_type",   # replaced by "product_base_type" in ayon-core 1.8.0
+    "family",
 }
 """Legacy placeholder keys that are deprecated but still supported for
 backward compatibility.


### PR DESCRIPTION
## Changelog Description
includes `product_type` as a LEGACY_PLACEHOLDER_KEYS

## Additional review information
`get_placeholder_keys` only returns the latest set of supported keys.
`product_type` is deprecated but still supported by ayon-core and used in many old scenes/templates.

this is an alternative solution to https://github.com/ynput/ayon-nuke/pull/210.

## Testing notes:
1. get an old placeholder node that uses `product type` and a new one (I pasted 2 example nodes here)
2. (optional) run the attached python script to confirm that old values are still supported
3. run "build workfile from template" and check if both get recognised 


## Example Nodes
```
set cut_paste_input [stack 0]
version 15.2 v7
push $cut_paste_input
NoOp {
 name NEW_PLACEHOLDER
 tile_color 0xff0000ff
 selected true
 xpos -299
 ypos -167
 addUserKnob {20 User}
 addUserKnob {1 builder_type l Builder_type}
 builder_type context_folder
 addUserKnob {1 link_type l Link_type}
 link_type template
 addUserKnob {1 product_base_type l Product_base_type}
 product_base_type plate
 addUserKnob {1 representation l Representation}
 representation exr
 addUserKnob {1 loader l Loader}
 loader LoadClip
 addUserKnob {1 loader_args l Loader_args}
 addUserKnob {3 order l Order}
 addUserKnob {1 folder_path l Folder_path}
 addUserKnob {1 product_name l Product_name}
 addUserKnob {1 plugin_identifier l Plugin_identifier}
 plugin_identifier nuke.load
 addUserKnob {6 is_placeholder l Is_placeholder +HIDDEN +STARTLINE}
 is_placeholder true
}
NoOp {
 inputs 0
 name OLD_PLACEHOLDER
 tile_color 0xff0000ff
 selected true
 xpos -300
 ypos -236
 addUserKnob {20 User}
 addUserKnob {1 builder_type l Builder_type}
 builder_type context_folder
 addUserKnob {1 product_type l Product_type}
 product_type plate
 addUserKnob {1 representation l Representation}
 representation exr
 addUserKnob {1 loader l Loader}
 loader LoadClip
 addUserKnob {1 loader_args l Loader_args}
 addUserKnob {3 order l Order}
 addUserKnob {1 folder_path l Folder_path}
 addUserKnob {1 product_name l Product_name}
 product_name .*plateL02.*
 addUserKnob {1 plugin_identifier l Plugin_identifier}
 plugin_identifier nuke.load
 addUserKnob {6 is_placeholder l Is_placeholder +HIDDEN +STARTLINE}
 is_placeholder true
}

```

## Test Script
```py
from ayon_core.pipeline import registered_host
from ayon_nuke.api import workfile_template_builder


host = registered_host()
builder = workfile_template_builder.NukeTemplateBuilder(host)


for placeholder in builder.get_placeholders():
    print(placeholder)
    for k in ["product_base_type", "product_type", "family"]:
        print(f"\t {k}",  placeholder.data.get(k, "NOT SET"))
```

expected output
```
*** WRN: >>> { <load_placeholder.NukePlaceholderLoadPlugin object at 0x7fcc0c16db40> }: [ Legacy placeholder key 'product_type' on 'OLD_PLACEHOLDER' is deprecated and will be removed in the future.
Please recreate the placeholder to fix this. ] 
< LoadPlaceholderItem NEW_PLACEHOLDER >
	 product_base_type plate
	 product_type NOT SET
	 family NOT SET
< LoadPlaceholderItem OLD_PLACEHOLDER >
	 product_base_type None
	 product_type plate
	 family NOT SET
```
