### PR TITLE
fix IncrementWriteNodePath plugin name to match settings key

### DIFF
--- a/client/ayon_nuke/plugins/publish/increment_write_node.py
+++ b/client/ayon_nuke/plugins/publish/increment_write_node.py
@@ -9,7 +9,7 @@ from ayon_core.pipeline import OptionalPyblishPluginMixin
 from ayon_nuke.api.lib import writes_version_sync
 
 
-class IncrementWriteNodePathPostSubmit(
+class IncrementWriteNodePath(
     pyblish.api.InstancePlugin, OptionalPyblishPluginMixin
 ):
     """Increments render path in write node with actual workfile version after


### PR DESCRIPTION
## Changelog Description
rename `IncrementWriteNodePathPostSubmit` to match the name used in the Server Settings

## Additional review information

the plugins settings are stored under `IncrementWriteNodePath` ([ref](https://github.com/ynput/ayon-nuke/blob/develop/server/settings/publish_plugins.py#L310))

## Testing notes:
1. change the settings to `IncrementWriteNodePath`
2. confirm they are getting applied on publish

example config I've used:
```json
{
  "publish": {
    "IncrementWriteNodePath": {
      "active": false,
      "enabled": false,
      "optional": true
    }
  }
}
```

