### PR TITLE
Set read colorspace: Skip read nodes with `None` as filename value

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1200,7 +1200,7 @@ def create_write_node(
     prev_node = None
     with GN:
         if input:
-            input_name = str(input.name()).replace("regex_inputs", "")
+            input_name = str(input.name()).replace(" ", "")
             # if connected input node was defined
             prev_node = nuke.createNode(
                 "Input",
@@ -2021,7 +2021,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
             log.error(_error)
 
         log.info("Setting colorspace to read nodes...")
-        read_clrs_inputs = nuke_colorspace[" "].get("inputs", [])
+        read_clrs_inputs = nuke_colorspace["regex_inputs"].get("inputs", [])
         if read_clrs_inputs:
             self.set_reads_colorspace(read_clrs_inputs)
 


### PR DESCRIPTION
## Changelog Description

Set read colorspace: Skip read nodes with `None` as filename value

## Additional review information

Also includes some cosmetic fixes

Previous error:

```py
>>> [ Setting colorspace to read nodes... ]
Traceback (most recent call last):
  File "C:\Program Files/Nuke16.0v4/plugins\nuke_internal\callbacks.py", line 82, in onScriptLoad
    _doCallbacks(onScriptLoads)
  File "C:\Program Files/Nuke16.0v4/plugins\nuke_internal\callbacks.py", line 46, in _doCallbacks
    f[0](*f[1],**f[2])
  File "C:\roydev\dev\ayon-nuke\client\ayon_nuke\api\lib.py", line 2139, in set_context_settings
    self.set_colorspace()
  File "C:\roydev\dev\ayon-nuke\client\ayon_nuke\api\lib.py", line 1998, in set_colorspace
    self.set_reads_colorspace(read_clrs_inputs)
  File "C:\roydev\dev\ayon-nuke\client\ayon_nuke\api\lib.py", line 1936, in set_reads_colorspace
    if not bool(re.search(input["regex"], file)):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Nuke16.0v4\python311.zip\re\__init__.py", line 176, in search
TypeError: expected string or bytes-like object, got 'NoneType'
```

<img width="417" height="154" alt="image" src="https://github.com/user-attachments/assets/7421e304-bb9a-46ef-bd37-83b69715b9d9" />


## Testing notes:
1. Create a Read node without any file path set.
2. Save scene.
3. Open scene file (e.g. on launch)

It should not error.
