### PR TITLE
Load Placeholder: Ignore backdrops as "connectable" in populating from placeholders

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2770,6 +2770,12 @@ def get_group_io_nodes(nodes):
     if not nodes:
         raise ValueError("there is no nodes in the list")
 
+    nodes = [
+        node for node in nodes
+        # Avoid non-connectable nodes, like Backdrops
+        if node.maxInputs() > 0 or node.maxOutputs() > 0
+    ]
+
     input_node = None
     output_node = None
 


### PR DESCRIPTION
## Changelog Description

Load Placeholder: Ignore backdrops as "connectable" in populating from placeholders

## Additional review information

It should now always try to reconnect/preserve connections for Impot Nuke Nodes that are just a single node on a backdrop node.

Fix #229 

I'm testing the builds just with:
```python
# Nuke: Populate/build currently opened scene using template builder within active context
from ayon_core.pipeline import registered_host
from ayon_nuke.api.workfile_template_builder import NukeTemplateBuilder

builder = NukeTemplateBuilder(registered_host())
builder.populate_scene_placeholders(keep_placeholders=True)
```
Just so I can run that logic quickly.

## Testing notes:

1. Template builder load should be able to transfer connection from placeholder to "Import Nuke Nodes" if what's loaded is just a single node on a backdrop.