### PR TITLE
Fix/render on farm button

### DIFF
--- a/client/ayon_nuke/api/utils.py
+++ b/client/ayon_nuke/api/utils.py
@@ -125,12 +125,11 @@ def _submit_render_on_farm(node) -> bool:
     host = registered_host()
     create_context = CreateContext(host)
 
-    # Ensure CreateInstance is enabled.
+    # Ensure only the target CreateInstance is enabled, deactivate all others.
     for instance in create_context.instances:
-        if node.name() != instance.transient_data["node"].name():
-            continue
-
-        instance.data["active"] = True
+        instance.data["active"] = (
+            node.name() == instance.transient_data["node"].name()
+        )
 
     context = pyblish.api.Context()
     context.data["create_context"] = create_context


### PR DESCRIPTION
Changelog Description

Fix "Render On Farm" button submits all active write nodes instead of only the clicked one.

## Additional review information

When clicking "Render On Farm" on a write node, the old code only sets `active=True` for the matching instance without deactivating the others. `CollectFromCreateContext` (order `CollectorOrder - 0.5`) collects all `active=True` instances before `CollectRenderOnFarm` (order `CollectorOrder - 0.49`) can deactivate them, so any write node already enabled in the publish window would also get submitted to the farm.

The fix explicitly sets `active=False` for all non-matching instances in `_submit_render_on_farm` before pyblish runs, so they are never collected into the context.

Closes #167

## Testing notes:

1. Create two or more write nodes with `render_on_farm` enabled in instance attributes.
2. Ensure all write nodes are active in the publish window, then close it.
3. Click **Render On Farm** on one write node — verify only that node appears as a job in Deadline.
4. Repeat for a different write node and confirm the same isolation behaviour.
5. Verify a normal publish (via the publish window with multiple nodes active) is unaffected — all active nodes still publish as expected.