### PR TITLE
Implement fallback for `BackdropNode.getNodes()` in headless mode

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1430,9 +1430,9 @@ def get_backdrop_nodes(backdrop_node):
     y_max = y_min + backdrop_node["bdheight"].value()
     contained = []
     for node in nuke.allNodes(
-            group=backdrop_node.parent(),
-            recurseGroups=False
-        ):
+        group=backdrop_node.parent(),
+        recurseGroups=False
+    ):
         if node is backdrop_node:
             continue
 

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1403,6 +1403,56 @@ def color_gui_to_int(color_gui):
     return int(hex_value, 16)
 
 
+def get_backdrop_nodes(backdrop_node):
+    """Return all nodes contained within a backdrop node.
+
+    In GUI mode uses the native ``BackdropNode.getNodes()`` method.
+    In headless/terminal mode that method is unavailable, so we fall back
+    to a manual positional check: any node whose top-left corner (xpos, ypos)
+    falls inside the backdrop's bounding rectangle is considered a member.
+
+    Args:
+        backdrop_node (nuke.BackdropNode): The backdrop node to query.
+
+    Returns:
+        list[nuke.Node]: Nodes contained within the backdrop.
+    """
+    if nuke.GUI:
+        return backdrop_node.getNodes()
+
+    # Headless fallback: find nodes whose position falls inside the backdrop.
+    # Note: this may include nodes that are inside only partially (by their top
+    # left corner) instead of the full node because `node.screenWidth()` and
+    # `node.screenHeight()` always return 0 in terminal mode.
+    x_min = backdrop_node.xpos()
+    y_min = backdrop_node.ypos()
+    x_max = x_min + backdrop_node["bdwidth"].value()
+    y_max = y_min + backdrop_node["bdheight"].value()
+    contained = []
+    for node in nuke.allNodes(
+            group=backdrop_node.parent(),
+            recurseGroups=False
+        ):
+        if node is backdrop_node:
+            continue
+
+        # Skip if out of bounds
+        node_x_min = node.xpos()
+        if node_x_min < x_min:
+            continue
+        node_y_min = node.ypos()
+        if node_y_min < y_min:
+            continue
+        node_x_max = node_x_min + node.screenWidth()
+        if node_x_max > x_max:
+            continue
+        node_y_max = node_y_min + node.screenHeight()
+        if node_y_max > y_max:
+            continue
+        contained.append(node)
+    return contained
+
+
 def create_backdrop(label="", color=None, layer=0,
                     nodes=None):
     """

--- a/client/ayon_nuke/plugins/load/load_backdrop.py
+++ b/client/ayon_nuke/plugins/load/load_backdrop.py
@@ -6,6 +6,7 @@ import ayon_api
 from ayon_core.pipeline import load
 from ayon_nuke.api.lib import (
     find_free_space_to_paste_nodes,
+    get_backdrop_nodes,
     maintained_selection,
     reset_selection,
     select_nodes,
@@ -202,7 +203,7 @@ class LoadBackdropNodes(load.LoaderPlugin):
         avalon_data = get_avalon_knob_data(GN)
 
         # Preserve external connections (to/from outside the backdrop)
-        backdrop_nodes = GN.getNodes()
+        backdrop_nodes = get_backdrop_nodes(GN)
         with restore_node_connections(backdrop_nodes):
             for node in backdrop_nodes:
                 # Delete old backdrop nodes
@@ -242,7 +243,7 @@ class LoadBackdropNodes(load.LoaderPlugin):
         node = container["node"]
         with viewer_update_and_undo_stop():
             if self.remove_nodes_from_backdrop:
-                for child_node in node.getNodes():
+                for child_node in get_backdrop_nodes(node):
                     nuke.delete(child_node)
             nuke.delete(node)
 

--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -188,7 +188,7 @@ class LoadClip(plugin.NukeLoader):
                     version_entity,
                     repre_entity
                 )
-            if first and last:
+            if first is not None and last is not None:
                 self._set_range_to_node(
                     read_node, first, last, start_at_workfile, slate_frames
                 )

--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -188,7 +188,7 @@ class LoadClip(plugin.NukeLoader):
                     version_entity,
                     repre_entity
                 )
-            if first is not None and last is not None:
+            if first and last:
                 self._set_range_to_node(
                     read_node, first, last, start_at_workfile, slate_frames
                 )

--- a/client/ayon_nuke/plugins/publish/collect_backdrop.py
+++ b/client/ayon_nuke/plugins/publish/collect_backdrop.py
@@ -20,7 +20,7 @@ class CollectBackdrops(pyblish.api.InstancePlugin):
         backdrop_node: nuke.BackdropNode = transient_data["node"]
 
         child_nodes: list[nuke.Node] = [
-            node for node in backdrop_node.getNodes()
+            node for node in lib.get_backdrop_nodes(backdrop_node)
             # exclude viewer
             if node.Class() != "Viewer"
         ]

--- a/client/ayon_nuke/plugins/workfile_build/create_placeholder.py
+++ b/client/ayon_nuke/plugins/workfile_build/create_placeholder.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import nuke
 
 from ayon_core.pipeline.workfile.workfile_template_builder import (
@@ -6,6 +7,7 @@ from ayon_core.pipeline.workfile.workfile_template_builder import (
 )
 from ayon_nuke.api.lib import (
     find_free_space_to_paste_nodes,
+    get_backdrop_nodes,
     get_extreme_positions,
     get_group_io_nodes,
     imprint,
@@ -268,14 +270,14 @@ class NukePlaceholderCreatePlugin(
         min_x, min_y, max_x, max_y = get_extreme_positions(considered_nodes)
 
         diff_x = diff_y = 0
-        contained_nodes = []  # for backdrops
+        contained_nodes: set[nuke.Node] = set()  # for backdrops
 
         if offset_y is None:
             width_ph = placeholder_node.screenWidth()
             height_ph = placeholder_node.screenHeight()
             diff_y = max_y - min_y - height_ph
             diff_x = max_x - min_x - width_ph
-            contained_nodes = [placeholder_node]
+            contained_nodes = {placeholder_node}
             min_x = placeholder_node.xpos()
             min_y = placeholder_node.ypos()
         else:
@@ -283,7 +285,7 @@ class NukePlaceholderCreatePlugin(
             minX, _, maxX, _ = get_extreme_positions(siblings)
             diff_y = max_y - min_y + 20
             diff_x = abs(max_x - min_x - maxX + minX)
-            contained_nodes = considered_nodes
+            contained_nodes = set(considered_nodes)
 
         if diff_y <= 0 and diff_x <= 0:
             return
@@ -301,7 +303,7 @@ class NukePlaceholderCreatePlugin(
                 not isinstance(node, nuke.BackdropNode)
                 or (
                     isinstance(node, nuke.BackdropNode)
-                    and not set(contained_nodes) <= set(node.getNodes())
+                    and not contained_nodes <= set(get_backdrop_nodes(node))
                 )
             ):
                 if offset_y is None and node.xpos() >= min_x:

--- a/client/ayon_nuke/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_nuke/plugins/workfile_build/load_placeholder.py
@@ -6,6 +6,7 @@ from ayon_core.pipeline.workfile.workfile_template_builder import (
 )
 from ayon_nuke.api.lib import (
     find_free_space_to_paste_nodes,
+    get_backdrop_nodes,
     get_extreme_positions,
     get_group_io_nodes,
     imprint,
@@ -328,7 +329,7 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
                 not isinstance(node, nuke.BackdropNode)
                 or (
                     isinstance(node, nuke.BackdropNode)
-                    and not set(contained_nodes) <= set(node.getNodes())
+                    and not set(contained_nodes) <= set(get_backdrop_nodes(node))
                 )
             ):
                 if offset_y is None and node.xpos() >= min_x:

--- a/client/ayon_nuke/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_nuke/plugins/workfile_build/load_placeholder.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import nuke
 
 from ayon_core.pipeline.workfile.workfile_template_builder import (
@@ -296,14 +297,14 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
         min_x, min_y, max_x, max_y = get_extreme_positions(considered_nodes)
 
         diff_x = diff_y = 0
-        contained_nodes = []  # for backdrops
+        contained_nodes: set[nuke.Node] = set()  # for backdrops
 
         if offset_y is None:
             width_ph = placeholder_node.screenWidth()
             height_ph = placeholder_node.screenHeight()
             diff_y = max_y - min_y - height_ph
             diff_x = max_x - min_x - width_ph
-            contained_nodes = [placeholder_node]
+            contained_nodes = {placeholder_node}
             min_x = placeholder_node.xpos()
             min_y = placeholder_node.ypos()
         else:
@@ -311,7 +312,7 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
             minX, _, maxX, _ = get_extreme_positions(siblings)
             diff_y = max_y - min_y + 20
             diff_x = abs(max_x - min_x - maxX + minX)
-            contained_nodes = considered_nodes
+            contained_nodes = set(considered_nodes)
 
         if diff_y <= 0 and diff_x <= 0:
             return
@@ -329,7 +330,7 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
                 not isinstance(node, nuke.BackdropNode)
                 or (
                     isinstance(node, nuke.BackdropNode)
-                    and not set(contained_nodes) <= set(get_backdrop_nodes(node))
+                    and not contained_nodes <= set(get_backdrop_nodes(node))
                 )
             ):
                 if offset_y is None and node.xpos() >= min_x:


### PR DESCRIPTION
## Changelog Description

Implement fallback for `BackdropNode.getNodes()` in headless mode

## Additional review information

Fix #233

Avoids error message:
```
RuntimeError: This method is only available in GUI mode
```

## Testing notes:

1. Workfile Template Builder should work with loading placeholders (and Import Nuke Nodes) in headless mode and still be able to transfer in/out connections
2. No errors upon updating loaded backdrops in headless mode
