### PR TITLE
Load Clip: Allow setting frame range from version data if frame start or frame end is 0

### DIFF
--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -188,7 +188,7 @@ class LoadClip(plugin.NukeLoader):
                     version_entity,
                     repre_entity
                 )
-            if first and last:
+            if first is not None and last is not None:
                 self._set_range_to_node(
                     read_node, first, last, start_at_workfile, slate_frames
                 )


### PR DESCRIPTION
## Changelog Description

Load Clip: Allow setting frame range from version data if frame start or frame end is 0

## Additional review information

...

## Testing notes:
1. Publish media (e.g. a video file) with a frame range version data like 0-100
2. When loading this clip the frame range should be set to 0-100 and go through the `_set_range_to_node` logic