### PR TITLE
Load Clip: Make set frame range optional

### DIFF
--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -201,6 +201,7 @@ class LoadClip(plugin.NukeLoader):
 
             data_imprint = {
                 "version": version_name,
+                "option_set_start_frame": set_frame_range
             }
 
             # add attributes from the version to imprint metadata knob
@@ -305,7 +306,9 @@ class LoadClip(plugin.NukeLoader):
         self.log.debug("_ filepath: {}".format(filepath))
 
         start_at_workfile = "start at" in read_node['frame_mode'].value()
-        set_frame_range = self.options_defaults["set_frame_range"]
+        set_frame_range: bool = container.get("option_set_start_frame",
+            self.options_defaults["set_frame_range"]
+        )
 
         add_retime = [
             key for key in read_node.knobs().keys()

--- a/client/ayon_nuke/plugins/load/load_clip.py
+++ b/client/ayon_nuke/plugins/load/load_clip.py
@@ -63,7 +63,8 @@ class LoadClip(plugin.NukeLoader):
 
     # option gui
     options_defaults = {
-        "start_at_workfile": True,
+        "set_frame_range": True,
+        "start_at_workfile": False,
         "add_retime": True,
         "node_type": "auto",
     }
@@ -73,6 +74,11 @@ class LoadClip(plugin.NukeLoader):
     @classmethod
     def get_options(cls, *args):
         return [
+            BoolDef(
+                "set_frame_range",
+                label="Set frame range from version data",
+                default=cls.options_defaults["set_frame_range"]
+            ),
             BoolDef(
                 "start_at_workfile",
                 label="Start at workfile's start frame",
@@ -124,10 +130,12 @@ class LoadClip(plugin.NukeLoader):
         filepath = filepath.replace("\\", "/")
         self.log.debug("_ filepath: {}".format(filepath))
 
-        start_at_workfile = options.get(
+        start_at_workfile: bool = options.get(
             "start_at_workfile", self.options_defaults["start_at_workfile"])
-
-        add_retime = options.get(
+        set_frame_range: bool = options.get(
+            "set_frame_range", self.options_defaults["set_frame_range"]
+        )
+        add_retime: bool = options.get(
             "add_retime", self.options_defaults["add_retime"])
 
         repre_id = repre_entity["id"]
@@ -181,7 +189,7 @@ class LoadClip(plugin.NukeLoader):
                     version_entity,
                     repre_entity
                 )
-            if first is not None and last is not None:
+            if set_frame_range and first is not None and last is not None:
                 self._set_range_to_node(read_node, first, last)
 
             if start_at_workfile:
@@ -297,6 +305,7 @@ class LoadClip(plugin.NukeLoader):
         self.log.debug("_ filepath: {}".format(filepath))
 
         start_at_workfile = "start at" in read_node['frame_mode'].value()
+        set_frame_range = self.options_defaults["set_frame_range"]
 
         add_retime = [
             key for key in read_node.knobs().keys()
@@ -331,7 +340,7 @@ class LoadClip(plugin.NukeLoader):
                     version_entity,
                     repre_entity
                 )
-            if first is not None and last is not None:
+            if set_frame_range and first is not None and last is not None:
                 self._set_range_to_node(read_node, first, last)
             else:
                 first = int(read_node['first'].value())

--- a/server/settings/loader_plugins.py
+++ b/server/settings/loader_plugins.py
@@ -40,7 +40,7 @@ class LoadClipOptionsModel(BaseSettingsModel):
     set_frame_range: bool = SettingsField(
         title="Set frame range to version frame range",
         description=(
-            "On load set the node's frame range to version frame range"
+            "When loading, set the node's frame range to the version's frame range."
         )
     )
     start_at_workfile: bool = SettingsField(

--- a/server/settings/loader_plugins.py
+++ b/server/settings/loader_plugins.py
@@ -37,6 +37,12 @@ def node_type_enum_options():
 
 
 class LoadClipOptionsModel(BaseSettingsModel):
+    set_frame_range: bool = SettingsField(
+        title="Set frame range to version frame range",
+        description=(
+            "On load set the node's frame range to version frame range"
+        )
+    )
     start_at_workfile: bool = SettingsField(
         title="Start at workfile's start frame"
     )
@@ -108,6 +114,7 @@ DEFAULT_LOADER_PLUGINS_SETTINGS = {
         "representations_include": [],
         "node_name_template": "{class_name}_{ext}",
         "options_defaults": {
+            "set_frame_range": True,
             "start_at_workfile": False,
             "add_retime": True,
             "node_type": "auto"


### PR DESCRIPTION
## Changelog Description

Load Clip: Make set frame range optional

## Additional review information

Whenever version data is invalid for a clip you may not want to have it apply the frame range data accordingly.

## Testing notes:

1. Load Clip should still work
2. Optional "Set frame range" option box should work as expected
3. Update loaded clip should work