### PR TITLE
Do not evaluate string knobs as expressions when getting their values

### DIFF
--- a/client/ayon_nuke/api/workfile_template_builder.py
+++ b/client/ayon_nuke/api/workfile_template_builder.py
@@ -105,10 +105,18 @@ class NukePlaceholderPlugin(PlaceholderPlugin):
     def _parse_placeholder_node_data(self, node: nuke.Node):
         placeholder_data: dict[str, Any] = {}
 
+        def _get_knob_value(knob):
+            if isinstance(knob, (nuke.EvalString_Knob, nuke.String_Knob)):
+                # Do not evaluate the contents, return us the exact
+                # text value we put in
+                return knob.getText()
+            else:
+                return knob.getValue()
+
         # collect current placeholder keys
         for key in self.get_placeholder_keys():
             if knob := node.knob(key):
-                placeholder_data[key] = knob.getValue()
+                placeholder_data[key] = _get_knob_value(knob)
             else:
                 placeholder_data[key] = None
 
@@ -124,7 +132,7 @@ class NukePlaceholderPlugin(PlaceholderPlugin):
                     " is deprecated and will be removed in the future."
                     "\nPlease recreate the placeholder to fix this."
                 )
-                placeholder_data[key] = knob.getValue()
+                placeholder_data[key] = _get_knob_value(knob)
 
         return placeholder_data
 

--- a/client/ayon_nuke/api/workfile_template_builder.py
+++ b/client/ayon_nuke/api/workfile_template_builder.py
@@ -107,8 +107,8 @@ class NukePlaceholderPlugin(PlaceholderPlugin):
 
         def _get_knob_value(knob):
             if isinstance(knob, (nuke.EvalString_Knob, nuke.String_Knob)):
-                # Do not evaluate the contents, return us the exact
-                # text value we put in
+                # Do not evaluate the contents; return the exact
+                # text value we set
                 return knob.getText()
             else:
                 return knob.getValue()


### PR DESCRIPTION
## Changelog Description

Do not evaluate string knobs as expressions when getting their values

## Additional review information

Whenever a string knob in nuke has text content that Nuke thinks has an assignment operation, like e.g. list comprehension or a return statement then when requesting the knob's value it will evaluate it like a Python script instead of just returning the actual text content of the knob. Due to the Script Placeholder holding actual scripts in these attributes we do not want to evaluate them whatsoever, we want their text contents because we'll be evaluating it ourselves when we run template build

Otherwise a script like e.g. this:
```python
import nuke

# Access the placeholder node
placeholder_identifier = placeholder.scene_identifier
node = nuke.toNode(placeholder_identifier)

# Set knob values on inputs if the knobs exist
values = {
  "direction": 1,
}

# Apply values to the input nodes
input_nodes = [node.input(i) for i in range(node.inputs()) if node.input(i) is not None]
for input_node in input_nodes:
    print(f"Processing input node: {input_node}")
    for name, value in values.items():
        knob = input_node.knob(name)
        knob_label = f"{input_node.name()}.{name}"
        if knob:
            print(f"Setting {knob_label} to: {value}")
            knob.setValue(value)
        else:
            print(f"No knob found for: {knob_label}")
```
Will not work because it'd evaluate as we try to get the text value instead of giving us the script to run in the build.

## Testing notes:

1. Script placeholder should work correctly on build
2. "Update placeholder" should also continue to show the correct values if initially the value was set to that script.
