### PR TITLE
enforce rgb as channels for intermediate review export mov

### DIFF
--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1411,7 +1411,11 @@ class ExporterReviewMov(ExporterReview):
 
         write_node["file"].setValue(str(self.path))
         write_node["file_type"].setValue(str(self.ext))
-        write_node["channels"].setValue(str(self.color_channels))
+        skip_alpha_channel = kwargs.get("skip_alpha_channel", False)
+        if skip_alpha_channel:
+            write_node["channels"].setValue("rgb")
+        else:
+            write_node["channels"].setValue(str(self.color_channels))
 
         # Knobs `meta_codec` and `mov64_codec` are not available on centos.
         # TODO shouldn't this come from settings on outputs?

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -152,6 +152,10 @@ class IntermediateOutputModel(BaseSettingsModel):
         False,
         title="Publish"
     )
+    skip_alpha_channel: bool = SettingsField(
+        False,
+        title="Skip alpha channel for review intermediates"
+    )
     filter: BakingStreamFilterModel = SettingsField(
         title="Filter", default_factory=BakingStreamFilterModel)
     read_raw: bool = SettingsField(
@@ -376,6 +380,7 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
             {
                 "name": "baking",
                 "publish": False,
+                "skip_alpha_channel": False,
                 "filter": {
                     "task_types": [],
                     "product_base_types": [],


### PR DESCRIPTION
## Changelog Description
This PR is to enforce the rgba as channels for the intermediate review export. By this, this would ensure the image won't be exported with black thumbnail as they are with the channels other than rgb.

Resolve https://github.com/ynput/ayon-nuke/issues/208

## Additional review information
n/a

## Testing notes:
1. `ayon+settings://nuke/create/CreateWriteRender/knob_overrides` or similar setting for the write node creators to add the knob overridden value
2. Create Prerender or use any write node creator product type to create instance
3. Add the knob channels to display the channel data
4. Publish
5. Should show up the thumbnail as reviewables in the server

