### PR TITLE
Settings: Change label to product base type

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -77,7 +77,7 @@ class CollectSyncWorkfileVersionModel(BaseSettingsModel):
     sync_workfile_version_on_product_base_types: list[str] = SettingsField(
         default_factory=list,
         enum_resolver=nuke_product_base_types_enum,
-        title="Product types"
+        title="Product base types"
     )
 
 


### PR DESCRIPTION
## Changelog Description
Changed label to `Product base types` instead of `Product types`.