### PR TITLE
AYON dependency package slipped in front of the python path

### DIFF
--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -2,6 +2,8 @@ import nuke
 
 import os
 import importlib
+import re
+import sys
 from collections import OrderedDict, defaultdict
 
 import pyblish.api
@@ -127,6 +129,21 @@ class NukeHost(
 
     def install(self):
         """Installing all requirements for Nuke host"""
+
+        # Ensure AYON dependencies
+        # override any modules packaged
+        # with Nuke. (e.g. opentimelineio)
+        for include_path in sys.path:
+            # TODO: this I know isn't a great way to do this.
+            # quite hacky. I asked for advice on Discord, but
+            # haven't seen a reply yet, but thought I'd push this
+            # so it's there to be seen.
+            if not re.search("/dependency_packages/.*/dependencies/?", include_path):
+                continue
+
+            sys.path.remove(include_path)
+            sys.path.insert(0, include_path)
+            break
 
         pyblish.api.register_host("nuke")
 


### PR DESCRIPTION
## Changelog Description
AYON dependency package slipped in front of the python path to override any modules packaged with nuke (e.g. opentimelineio)