### PR TITLE
fix: only copy attributes if they exist

### DIFF
--- a/client/ayon_nuke/plugins/load/load_backdrop.py
+++ b/client/ayon_nuke/plugins/load/load_backdrop.py
@@ -66,7 +66,8 @@ class LoadBackdropNodes(load.LoaderPlugin):
 
         # add attributes from the version to imprint to metadata knob
         for k in ["source", "fps"]:
-            data_imprint[k] = version_attributes[k]
+            if k in version_attributes:
+                data_imprint[k] = version_attributes[k]
 
         # getting file path
         file = self.filepath_from_context(context).replace("\\", "/")
@@ -192,7 +193,8 @@ class LoadBackdropNodes(load.LoaderPlugin):
         }
 
         for k in ["source", "fps"]:
-            data_imprint[k] = version_attributes[k]
+            if k in version_attributes:
+                data_imprint[k] = version_attributes[k]
 
         # adding nodes to node graph
         # just in case we are in group lets jump out of it


### PR DESCRIPTION
## Changelog Description
Only copy `fps` and `source` if they exists on `version_attributes` 

## Additional review information

Its not uncommon for us to ingest nukenodes via the traypublisher (eg.: as part of deliveries from third party vendors)
Those products do not have an `fps` attribute and don't really need one either.

```
During load error happened on Product: "nukenodesLensDistortion" Representation: "nk" Version: 1

Error message: 'fps'

Traceback (most recent call last):
  File "/home/v/dev/ayon-core/client/ayon_core/tools/loader/models/actions.py", line 1005, in _load_representations_by_loader
    load_with_repre_context(
  File "/home/v/dev/ayon-core/client/ayon_core/pipeline/load/utils.py", line 327, in load_with_repre_context
    return loader.load(repre_context, name, namespace, options)
  File "/home/v/dev/ayon-core/client/ayon_core/pipeline/load/plugins.py", line 430, in wrapped_method
    result = original_method(self, *args, **kwargs)
  File "/home/v/dev/ayon-nuke/client/ayon_nuke/plugins/load/load_backdrop.py", line 70, in load
    data_imprint[k] = version_attributes[k]
KeyError: 'fps'
```


## Testing notes:
1. in nuke: create a node and export it into a file (`nuke.nodeCopy("/mnt/d/work/nodes.nk")`
2. configure trayPublisher to publish a `nukenodes` product type 
3. publish the `nodes.nk` from trayPublisher
4. load them back into nuke via AYON


example tray publisher config:
```
{
  "simple_creators": [
    {
      "icon": "",
      "label": "Lens Distortion Node",
      "extensions": [
        ".nk"
      ],
      "identifier": "",
      "description": "Ingest Nuke Lens Distortion Nodes from Tracking Outsource",
      "allow_sequences": false,
      "default_variants": [
        "LensDistortion"
      ],
      "product_base_type": "nukenodes",
      "product_type_items": [],
      "allow_multiple_items": false,
      "detailed_description": "",
      "allow_version_control": true
    }
  ]
}
```