### PR TITLE
Load Backdrop: Avoid scene connections breaking to selected nodes when loading backdrop

### DIFF
--- a/client/ayon_nuke/plugins/load/load_backdrop.py
+++ b/client/ayon_nuke/plugins/load/load_backdrop.py
@@ -75,15 +75,15 @@ class LoadBackdropNodes(load.LoaderPlugin):
         # just in case we are in group lets jump out of it
         nuke.endGroup()
 
-        # Get mouse position
-        n = nuke.createNode("NoOp")
-        xcursor, ycursor = (n.xpos(), n.ypos())
-        reset_selection()
-        nuke.delete(n)
-
-        bdn_frame = 50
-
         with maintained_selection():
+            # Get mouse position
+            reset_selection()  # clear selection first to avoid automatic connections to selection
+            n = nuke.createNode("NoOp")
+            xcursor, ycursor = (n.xpos(), n.ypos())
+            nuke.delete(n)
+
+            bdn_frame = 50
+
             # add group from nk
             nuke.nodePaste(file)
             # get all pasted nodes
@@ -120,7 +120,6 @@ class LoadBackdropNodes(load.LoaderPlugin):
                         d.setInput(index, dot)
 
                     # remove Input node
-                    reset_selection()
                     nuke.delete(n)
                     continue
 
@@ -139,7 +138,6 @@ class LoadBackdropNodes(load.LoaderPlugin):
                         dot.setInput(0, dep)
 
                     # remove Input node
-                    reset_selection()
                     nuke.delete(n)
                     continue
                 else:

--- a/client/ayon_nuke/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_nuke/plugins/workfile_build/load_placeholder.py
@@ -358,7 +358,7 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
 
         # Workaround: There are some cases where only the second call to `.dependent()` seems to
         #  start returning the input dependencies directly after a scene open (reproduced in Nuke 14.1)
-        #  so we just enforce and extra call to be sure this works as intended
+        #  so we just enforce an extra call to be sure this works as intended
         placeholder_node.dependent()
 
         for node in placeholder_node.dependent():

--- a/client/ayon_nuke/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_nuke/plugins/workfile_build/load_placeholder.py
@@ -355,6 +355,12 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
         input_node, output_node = get_group_io_nodes(
             placeholder.data["last_loaded"]
         )
+
+        # Workaround: There are some cases where only the second call to `.dependent()` seems to
+        #  start returning the input dependencies directly after a scene open (reproduced in Nuke 14.1)
+        #  so we just enforce and extra call to be sure this works as intended
+        placeholder_node.dependent()
+
         for node in placeholder_node.dependent():
             for idx in range(node.inputs()):
                 if node.input(idx) == placeholder_node and output_node:


### PR DESCRIPTION
## Changelog Description

Fixes issue where the scene may be losing existing connections if loading backdrop. The easiest way to reproduce is to select all nodes in the graph, load the placeholder. Previously it'd essentially break your scene.

## Additional review information

Reset selection before creating the NoOp to avoid the selection getting automatically connected to the input of the NoOp (default nuke behavior) + move the logic inside the maintained selection contextlib so that we do actually maintain the users selection as intended. Also, remove some redundant `reset_selection` calls before explicitly deleting a node (selection should not affect it.)

## Testing notes:

1. Load Placeholder should work.
