### PR TITLE
Fix(load_ociolook): strip extension before suffix match

### DIFF
--- a/client/ayon_nuke/plugins/load/load_ociolook.py
+++ b/client/ayon_nuke/plugins/load/load_ociolook.py
@@ -176,7 +176,7 @@ class LoadOcioLookNodes(load.LoaderPlugin):
                     (
                         file for file in all_files
                         if file.endswith(extension)
-                        and os.path.basename(file).endswith(lut_suffix)
+                        and os.path.splitext(os.path.basename(file))[0].endswith(lut_suffix)
                     ),
                     None
                 )

--- a/client/ayon_nuke/plugins/load/load_ociolook.py
+++ b/client/ayon_nuke/plugins/load/load_ociolook.py
@@ -176,7 +176,7 @@ class LoadOcioLookNodes(load.LoaderPlugin):
                     (
                         file for file in all_files
                         if file.endswith(extension)
-                        and os.path.splitext(os.path.basename(file))[0].endswith(lut_suffix)
+                        and os.path.splitext(file)[0].endswith(lut_suffix)
                     ),
                     None
                 )


### PR DESCRIPTION

Should fix the error when loading the published OCIOlook

```Traceback (most recent call last):
  File "/home/avril9950x3d/.local/share/AYON/addons/core_1.9.1+lbs.1/ayon_core/tools/loader/models/actions.py", line 1005, in _load_representations_by_loader
    load_with_repre_context(
  File "/home/avril9950x3d/.local/share/AYON/addons/core_1.9.1+lbs.1/ayon_core/pipeline/load/utils.py", line 327, in load_with_repre_context
    return loader.load(repre_context, name, namespace, options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/avril9950x3d/.local/share/AYON/addons/core_1.9.1+lbs.1/ayon_core/pipeline/load/plugins.py", line 430, in wrapped_method
    result = original_method(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/avril9950x3d/.local/share/AYON/addons/nuke_0.4.8/ayon_nuke/plugins/load/load_ociolook.py", line 61, in load
    group_node = self._create_group_node(
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/avril9950x3d/.local/share/AYON/addons/nuke_0.4.8/ayon_nuke/plugins/load/load_ociolook.py", line 184, in _create_group_node
    raise ValueError(
ValueError: File with extension 'cube' not found in directory```