### PR TITLE
Add logs on invalid nuke.root() format set.

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2174,8 +2174,17 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
             log.info("Creating new format: {}".format(format_string))
             nuke.addFormat(format_string)
 
-        nuke.root()["format"].setValue(format_data["name"])
-        log.info("Format is set.")
+        try:
+            nuke.root()["format"].setValue(format_data["name"])
+            log.info("Root format is set.")
+
+        except Exception as error:
+            log.error(
+                "Failed to set root format from %r: %r",
+                format_data,
+                error,
+            )
+            raise
 
         # update node graph so knobs are updated
         update_node_graph()

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2183,6 +2183,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
                 "Failed to set root format from %r: %r",
                 format_data,
                 error,
+                exc_info=True,
             )
             raise
 


### PR DESCRIPTION
## Changelog Description

Ensure logging report the actual format data when failing at setting the `nuke.root() format` from task attributes.

## Testing notes:
1. No feature changes
