### PR TITLE
Extract Backdrop: Avoid errors on reconnecting the inputs/outputs

### DIFF
--- a/client/ayon_nuke/plugins/publish/extract_backdrop.py
+++ b/client/ayon_nuke/plugins/publish/extract_backdrop.py
@@ -74,10 +74,6 @@ class ExtractBackdropNode(publish.Extractor):
             # save file to the path
             nuke.nodeCopy(path)
 
-            # Clean up
-            for tn in tmp_nodes:
-                nuke.delete(tn)
-
             # restore original connections
             # reconnect input node
             for n, inputs in connections_in.items():
@@ -89,6 +85,13 @@ class ExtractBackdropNode(publish.Extractor):
                 output.setInput(
                     next((i for i, d in enumerate(output.dependencies())
                           if d.name() in n.name()), 0), n)
+
+            # Fix #259: When deleting the temporary nodes before the reconnect
+            # of inputs and outputs the node Python Objects would somehow
+            # become invalid errors. So we do this cleanup after
+            # Clean up
+            for tn in tmp_nodes:
+                nuke.delete(tn)
 
         if "representations" not in instance.data:
             instance.data["representations"] = []

--- a/client/ayon_nuke/plugins/publish/extract_backdrop.py
+++ b/client/ayon_nuke/plugins/publish/extract_backdrop.py
@@ -86,9 +86,9 @@ class ExtractBackdropNode(publish.Extractor):
                     next((i for i, d in enumerate(output.dependencies())
                           if d.name() in n.name()), 0), n)
 
-            # Fix #259: When deleting the temporary nodes before the reconnect
-            # of inputs and outputs the node Python Objects would somehow
-            # become invalid errors. So we do this cleanup after
+            # Fix #259: Deleting the temporary Input/Output nodes before
+            # reconnecting can invalidate Nuke node Python objects.
+            # Perform cleanup only after the original connections are restored.
             # Clean up
             for tn in tmp_nodes:
                 nuke.delete(tn)


### PR DESCRIPTION
## Changelog Description

Avoid error on reconnect due to Nuke node Python Objects becoming invalid somehow after the temp node deletion (even though it's not deleting those original nodes)

## Additional review information

Fix #259 

## Testing notes:

1. Extract Backdrop should work
2. Connections should still persist as they were before extraction