### PR TITLE
Replace qargparse with attribute definitions

### DIFF
--- a/client/ayon_nuke/plugins/load/load_image.py
+++ b/client/ayon_nuke/plugins/load/load_image.py
@@ -59,7 +59,7 @@ class LoadImage(load.LoaderPlugin):
             default=int(nuke.root()["first_frame"].getValue()),
             min=1,
             max=999999,
-            help="What frame is reading from?"
+            tooltip="What frame is reading from?"
         )
     ]
 

--- a/client/ayon_nuke/plugins/load/load_image.py
+++ b/client/ayon_nuke/plugins/load/load_image.py
@@ -1,6 +1,5 @@
 import nuke
 
-import qargparse
 import ayon_api
 
 from ayon_core.pipeline import load
@@ -8,6 +7,7 @@ from ayon_core.pipeline import load
 from ayon_nuke.api.lib import (
     get_imageio_input_colorspace
 )
+from ayon_core.lib import NumberDef
 from ayon_core.pipeline.colorspace import (
     get_imageio_file_rules_colorspace_from_filepath,
     get_current_context_imageio_config_preset,
@@ -53,7 +53,7 @@ class LoadImage(load.LoaderPlugin):
     node_name_template = "{class_name}_{ext}"
 
     options = [
-        qargparse.Integer(
+        NumberDef(
             "frame_number",
             label="Frame Number",
             default=int(nuke.root()["first_frame"].getValue()),

--- a/client/ayon_nuke/plugins/load/load_image.py
+++ b/client/ayon_nuke/plugins/load/load_image.py
@@ -57,8 +57,8 @@ class LoadImage(load.LoaderPlugin):
             "frame_number",
             label="Frame Number",
             default=int(nuke.root()["first_frame"].getValue()),
-            min=1,
-            max=999999,
+            minimum=1,
+            maximum=999999,
             tooltip="What frame is reading from?"
         )
     ]


### PR DESCRIPTION
## Changelog Description

Replace qargparse with attribute definitions

## Additional review information

Clean up usage of `qargparse` and starting using AYON's attribute definitons.

## Testing notes:

1. Load options should still work
