### PR TITLE
Fix avalon knob data growing on version updates by removing node reference

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -428,6 +428,11 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
     data = data or dict()
     create = OrderedDict()
 
+    # remove node key from container data before
+    # setting it into the node's avalon knob
+    if "node" in data:
+        del data["node"]
+
     tab_name = NODE_TAB_NAME
     editable = ["folderPath", "productName", "name", "namespace"]
 

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -430,8 +430,11 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
 
     # remove node key from container data before
     # setting it into the node's avalon knob
-    if "node" in data:
-        del data["node"]
+    data = {
+        key: value
+        for key, value in data.items()
+        if key not in ("node", "objectName")
+    }
 
     tab_name = NODE_TAB_NAME
     editable = ["folderPath", "productName", "name", "namespace"]


### PR DESCRIPTION
## Changelog Description
Fixed an issue where the avalon knob data continuously grew in size with each version update in Scene Inventory. The problem occurred because the `node` key, containing a reference to the Nuke node object, was being serialized into the avalon knob data. This caused the knob to accumulate redundant node references on every update, bloating the node's data unnecessarily.

The fix removes the `node` key from the container data before setting it into the node's avalon knob, preventing the accumulation of node references and keeping the knob data clean and minimal.

## Additional info
The change is implemented in `set_avalon_knob_data()` function in `client/ayon_nuke/api/lib.py`. The `node` key is now explicitly removed from the data dictionary before the avalon knob is populated. This is safe because the node reference is not needed to be stored in the knob - it's only used during runtime operations and should not be persisted in the node's serialized data.

## Testing notes:
1. Load a container in Nuke Scene Inventory
2. Update the container to a newer version multiple times
3. Inspect the avalon knob data on the node - it should not grow with each update
4. Verify that container functionality (updates, switches, removals) works as expected

## Dependency
Close #252