### PR TITLE
Do not raise KnownPublishError if workfile is invalid / None during context data collection

### DIFF
--- a/client/ayon_nuke/plugins/publish/collect_context_data.py
+++ b/client/ayon_nuke/plugins/publish/collect_context_data.py
@@ -1,9 +1,8 @@
-import os
 import nuke
 import pyblish.api
 
 import ayon_nuke.api as napi
-from ayon_core.pipeline import KnownPublishError
+from ayon_core.pipeline import registered_host
 
 
 class CollectContextData(pyblish.api.ContextPlugin):
@@ -18,13 +17,7 @@ class CollectContextData(pyblish.api.ContextPlugin):
     def process(self, context):  # sourcery skip: avoid-builtin-shadow
         root_node = nuke.root()
 
-        current_file = os.path.normpath(root_node.name())
-
-        if current_file.lower() == "root":
-            raise KnownPublishError(
-                "Workfile is not correct file name. \n"
-                "Use workfile tool to manage the name correctly."
-            )
+        current_file = registered_host().get_current_workfile()
 
         # Get frame range
         first_frame = int(root_node["first_frame"].getValue())


### PR DESCRIPTION
## Changelog Description
The collector plugin `collect_context_data` does not raise a `KnownPublishError` anymore if the scene file is not saved.
Instead, this error is now properly caught by the ayon-core validator `validate_file_saved`.

## Additional review information
Fixes https://github.com/ynput/ayon-nuke/issues/280


## Testing notes:
1. Open Nuke, create publish instances.
2. Do not save the scene and try to publish.
3. Validation should fail and a descriptive error message appear.
