### PR TITLE
Make all validators optional

### DIFF
--- a/client/ayon_nuke/plugins/publish/validate_exposed_knobs.py
+++ b/client/ayon_nuke/plugins/publish/validate_exposed_knobs.py
@@ -47,7 +47,7 @@ class ValidateExposedKnobs(
     """
 
     order = pyblish.api.ValidatorOrder
-    optional = True
+    optional = False
     families = ["render", "prerender", "image"]
     label = "Validate Exposed Knobs"
     actions = [RepairExposedKnobs]

--- a/client/ayon_nuke/plugins/publish/validate_proxy_mode.py
+++ b/client/ayon_nuke/plugins/publish/validate_proxy_mode.py
@@ -27,7 +27,7 @@ class ValidateProxyMode(
     """Validate active proxy mode"""
 
     order = pyblish.api.ValidatorOrder
-    optional = True
+    optional = False
     label = "Validate Proxy Mode"
     hosts = ["nuke"]
     actions = [FixProxyMode]

--- a/client/ayon_nuke/plugins/publish/validate_proxy_mode.py
+++ b/client/ayon_nuke/plugins/publish/validate_proxy_mode.py
@@ -1,6 +1,9 @@
 import pyblish
 import nuke
-from ayon_core.pipeline import PublishXmlValidationError
+from ayon_core.pipeline import (
+    PublishXmlValidationError,
+    OptionalPyblishPluginMixin
+)
 
 
 class FixProxyMode(pyblish.api.Action):
@@ -17,10 +20,14 @@ class FixProxyMode(pyblish.api.Action):
         rootNode["proxy"].setValue(False)
 
 
-class ValidateProxyMode(pyblish.api.ContextPlugin):
+class ValidateProxyMode(
+    OptionalPyblishPluginMixin,
+    pyblish.api.ContextPlugin,
+):
     """Validate active proxy mode"""
 
     order = pyblish.api.ValidatorOrder
+    optional = True
     label = "Validate Proxy Mode"
     hosts = ["nuke"]
     actions = [FixProxyMode]
@@ -28,6 +35,8 @@ class ValidateProxyMode(pyblish.api.ContextPlugin):
     settings_category = "nuke"
 
     def process(self, context):
+        if not self.is_active(context.data):
+            return
 
         rootNode = nuke.root()
         isProxy = rootNode["proxy"].value()

--- a/client/ayon_nuke/plugins/publish/validate_proxy_mode.py
+++ b/client/ayon_nuke/plugins/publish/validate_proxy_mode.py
@@ -2,7 +2,7 @@ import pyblish
 import nuke
 from ayon_core.pipeline import (
     PublishXmlValidationError,
-    OptionalPyblishPluginMixin
+    OptionalPyblishPluginMixin,
 )
 
 

--- a/client/ayon_nuke/plugins/publish/validate_rendered_frames.py
+++ b/client/ayon_nuke/plugins/publish/validate_rendered_frames.py
@@ -3,7 +3,7 @@ import clique
 
 from ayon_core.pipeline import (
     PublishXmlValidationError,
-    OptionalPyblishPluginMixin
+    OptionalPyblishPluginMixin,
 )
 from ayon_core.pipeline.publish import get_errored_instances_from_context
 

--- a/client/ayon_nuke/plugins/publish/validate_rendered_frames.py
+++ b/client/ayon_nuke/plugins/publish/validate_rendered_frames.py
@@ -54,7 +54,7 @@ class ValidateRenderedFrames(
     """Validates file output."""
 
     order = pyblish.api.ValidatorOrder + 0.1
-    optional = True
+    optional = False
     families = ["render", "prerender", "still"]
 
     label = "Validate rendered frame"

--- a/client/ayon_nuke/plugins/publish/validate_rendered_frames.py
+++ b/client/ayon_nuke/plugins/publish/validate_rendered_frames.py
@@ -1,7 +1,10 @@
 import pyblish.api
 import clique
 
-from ayon_core.pipeline import PublishXmlValidationError
+from ayon_core.pipeline import (
+    PublishXmlValidationError,
+    OptionalPyblishPluginMixin
+)
 from ayon_core.pipeline.publish import get_errored_instances_from_context
 
 
@@ -44,10 +47,14 @@ class RepairCollectionActionToFarm(RepairActionBase):
         self.repair_knob(context, instances, "farm")
 
 
-class ValidateRenderedFrames(pyblish.api.InstancePlugin):
+class ValidateRenderedFrames(
+    OptionalPyblishPluginMixin,
+    pyblish.api.InstancePlugin
+):
     """Validates file output."""
 
     order = pyblish.api.ValidatorOrder + 0.1
+    optional = True
     families = ["render", "prerender", "still"]
 
     label = "Validate rendered frame"
@@ -57,6 +64,9 @@ class ValidateRenderedFrames(pyblish.api.InstancePlugin):
     settings_category = "nuke"
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         node = instance.data["transientData"]["node"]
 
         f_data = {

--- a/client/ayon_nuke/plugins/publish/validate_write_nodes.py
+++ b/client/ayon_nuke/plugins/publish/validate_write_nodes.py
@@ -53,7 +53,7 @@ class ValidateNukeWriteNode(
     """
 
     order = pyblish.api.ValidatorOrder
-    optional = True
+    optional = False
     families = ["render"]
     label = "Validate write node"
     actions = [RepairNukeWriteNodeAction]

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -371,22 +371,22 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
     },
     "ValidateExposedKnobs": {
         "enabled": True,
-        "optional": True,
+        "optional": False,  # match how it was before it was made optional
         "active": True
     },
     "ValidateProxyMode": {
         "enabled": True,
-        "optional": True,
+        "optional": False,  # match how it was before it was made optional
         "active": True
     },
     "ValidateRenderedFrames": {
         "enabled": True,
-        "optional": True,
+        "optional": False,  # match how it was before it was made optional
         "active": True
     },
     "ValidateNukeWriteNode": {
         "enabled": True,
-        "optional": True,
+        "optional": False,  # match how it was before it was made optional
         "active": True
     },
     "ValidateGizmo": {

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -273,6 +273,10 @@ class PublishPluginsModel(BaseSettingsModel):
         title="Validate Exposed Knobs",
         default_factory=OptionalPluginModel
     )
+    ValidateProxyMode: OptionalPluginModel = SettingsField(
+        title="Validate Proxy Mode",
+        default_factory=OptionalPluginModel
+    )
     ValidateGizmo: OptionalPluginModel = SettingsField(
         title="Validate Gizmo",
         default_factory=OptionalPluginModel
@@ -358,6 +362,11 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
         "active": True
     },
     "ValidateExposedKnobs": {
+        "enabled": True,
+        "optional": True,
+        "active": True
+    },
+    "ValidateProxyMode": {
         "enabled": True,
         "optional": True,
         "active": True

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -269,6 +269,10 @@ class PublishPluginsModel(BaseSettingsModel):
         title="Validate Output Resolution",
         default_factory=OptionalPluginModel
     )
+    ValidateExposedKnobs: OptionalPluginModel = SettingsField(
+        title="Validate Exposed Knobs",
+        default_factory=OptionalPluginModel
+    )
     ValidateGizmo: OptionalPluginModel = SettingsField(
         title="Validate Gizmo",
         default_factory=OptionalPluginModel
@@ -349,6 +353,11 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
         ])
     },
     "ValidateOutputResolution": {
+        "enabled": True,
+        "optional": True,
+        "active": True
+    },
+    "ValidateExposedKnobs": {
         "enabled": True,
         "optional": True,
         "active": True

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -277,6 +277,10 @@ class PublishPluginsModel(BaseSettingsModel):
         title="Validate Proxy Mode",
         default_factory=OptionalPluginModel
     )
+    ValidateRenderedFrames: OptionalPluginModel = SettingsField(
+        title="Validate Rendered Frames",
+        default_factory=OptionalPluginModel
+    )
     ValidateGizmo: OptionalPluginModel = SettingsField(
         title="Validate Gizmo",
         default_factory=OptionalPluginModel
@@ -367,6 +371,11 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
         "active": True
     },
     "ValidateProxyMode": {
+        "enabled": True,
+        "optional": True,
+        "active": True
+    },
+    "ValidateRenderedFrames": {
         "enabled": True,
         "optional": True,
         "active": True

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -281,6 +281,10 @@ class PublishPluginsModel(BaseSettingsModel):
         title="Validate Rendered Frames",
         default_factory=OptionalPluginModel
     )
+    ValidateNukeWriteNode: OptionalPluginModel = SettingsField(
+        title="Validate Nuke Write Node",
+        default_factory=OptionalPluginModel
+    )
     ValidateGizmo: OptionalPluginModel = SettingsField(
         title="Validate Gizmo",
         default_factory=OptionalPluginModel
@@ -376,6 +380,11 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
         "active": True
     },
     "ValidateRenderedFrames": {
+        "enabled": True,
+        "optional": True,
+        "active": True
+    },
+    "ValidateNukeWriteNode": {
         "enabled": True,
         "optional": True,
         "active": True


### PR DESCRIPTION
## Changelog Description
made `ValidateExposedKnobs`, `ValidateProxyMode`, `ValidateRenderedFrames` and `ValidateNukeWriteNode` optional

## Additional review information
initially I was planning to only update `ValidateExposedKnobs` but I figured while at it I'd update these too.
With the PR all `ayon-nuke` validators should be optional, allowing studios to disable them if they want to replace or simply not use them in their workflows.

## Testing notes:
1. disable any of these validators (either in server settings or publish settings)
2. publish
3. confirm they didn't run
