### PR TITLE
set reads colorspace - limit displayed items for long lists

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2040,15 +2040,19 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
             # to avoid display issues with long lists.
             MAX_ITEMS = 10
 
-            msg = "Read nodes are not set to the correct colorspace:\n\n"
-
             items = list(changes.items())
             details = []
 
+            msg = (
+                "Read node is not set to the correct colorspace:\n\n"
+                if len(items) == 1
+                else "Read nodes are not set to the correct colorspace:\n\n"
+            )
+
             for i, (node_name, knobs) in enumerate(items):
                 line = (
-                    " - node: '{0}' is now '{1}' but should be '{2}'"
-                    .format(node_name, knobs["from"], knobs["to"])
+                    f" - node: '{node_name}' is now '{knobs['from']}' "
+                    f"but should be '{knobs['to']}'"
                 )
                 details.append(line)
 
@@ -2059,12 +2063,16 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
             if remaining > 0:
                 print("\n".join(details))
                 msg += (
-                    "\n...and {} more nodes.\n"
+                    f"\n...and {remaining} more "
+                    f"{'node' if remaining == 1 else 'nodes'}.\n"
                     "\nA detailed list has been printed to the Script Editor."
-                ).format(remaining)
+                )
 
-            msg += "\n\n\nChange all of them?"
-
+            msg += (
+                "\n\nWould you like to change it?"
+                if len(items) == 1
+                else "\n\nWould you like to change them?"
+            )
 
             if nuke.ask(msg):
                 for node_name, knobs in changes.items():

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2036,13 +2036,35 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
                     }
 
         if changes:
-            msg = "Read nodes are not set to correct colorspace:\n\n"
-            for node_name, knobs in changes.items():
-                msg += (
-                    " - node: '{0}' is now '{1}' but should be '{2}'\n"
-                ).format(node_name, knobs["from"], knobs["to"])
+            # Limit items shown in the UI
+            # to avoid display issues with long lists.
+            MAX_ITEMS = 10
 
-            msg += "\nWould you like to change it?"
+            msg = "Read nodes are not set to the correct colorspace:\n\n"
+
+            items = list(changes.items())
+            details = []
+
+            for i, (node_name, knobs) in enumerate(items):
+                line = (
+                    " - node: '{0}' is now '{1}' but should be '{2}'"
+                    .format(node_name, knobs["from"], knobs["to"])
+                )
+                details.append(line)
+
+                if i < MAX_ITEMS:
+                    msg += line + "\n"
+
+            remaining = len(items) - MAX_ITEMS
+            if remaining > 0:
+                print("\n".join(details))
+                msg += (
+                    "\n...and {} more nodes.\n"
+                    "\nA detailed list has been printed to the Script Editor."
+                ).format(remaining)
+
+            msg += "\n\n\nChange all of them?"
+
 
             if nuke.ask(msg):
                 for node_name, knobs in changes.items():


### PR DESCRIPTION
## Changelog Description
This PR sets a size limit of 10 for items shown in the nuke.ask ui dialog inside the `set_reads_colorspace` method in the WorkfileSettings class to prevent display issues for long lists.

## Additional review information
Fixes https://github.com/ynput/ayon-nuke/issues/287

## Testing notes:
1. Create a nuke workfile with more than 10 read notes set to wrong intended colospace.
2. Apply colorspace settings via AYON menu.
3. The UI should limit the displayed nodes to 10 and print the whole list of nodes to fix in the script editor.
