### PR TITLE
fix: remove deprecated load from library

### DIFF
--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -372,13 +372,6 @@ def _install_menu(project_settings: dict):
     )
     menu.addSeparator()
     menu.addCommand(
-        "Library...",
-        lambda: host_tools.show_library_loader(
-            parent=main_window
-        )
-    )
-    menu.addSeparator()
-    menu.addCommand(
         "Set Resolution",
         lambda: WorkfileSettings().reset_resolution()
     )


### PR DESCRIPTION
## Changelog Description
remove deprecated `Library...` option form the menu

## Additional review information
`host_tools.show_library_loader` was removed in https://github.com/ynput/ayon-core/pull/1856
```
Traceback (most recent call last):
  File "/mnt/home/vincent.ullmann/.local/share/AYON/addons/nuke_0.4.10/ayon_nuke/api/pipeline.py", line 319, in <lambda>
    lambda: host_tools.show_library_loader(
AttributeError: module 'ayon_core.tools.utils.host_tools' has no attribute 'show_library_loader'
```

## Testing notes:
1. start with this step
2. follow this step
