### PR TITLE
Fix/camera selection

### DIFF
--- a/client/ayon_nuke/plugins/load/load_camera.py
+++ b/client/ayon_nuke/plugins/load/load_camera.py
@@ -167,10 +167,10 @@ class AlembicCameraLoader(load.LoaderPlugin):
             ypos = camera_node.ypos()
             camera_node.selectOnly()
             nuke.nodeCopy("%clipboard%")
-            camera_name = camera_node.name()
             nuke.delete(camera_node)
-            nuke.nodePaste("%clipboard%")
-            camera_node = nuke.toNode(camera_name)
+            camera_node = nuke.nodePaste("%clipboard%")
+            if not camera_node:
+                raise RuntimeError("Failed to paste camera node")
             camera_node.setXYpos(xpos, ypos)
 
             # link to original input nodes

--- a/client/ayon_nuke/plugins/load/load_camera.py
+++ b/client/ayon_nuke/plugins/load/load_camera.py
@@ -146,10 +146,14 @@ class AlembicCameraLoader(load.LoaderPlugin):
         # getting file path
         file = get_representation_path(repre_entity).replace("\\", "/")
 
-        with maintained_selection():
-            camera_node = container["node"]
-            camera_node['selected'].setValue(True)
+        camera_node = container["node"]
+        selected = camera_node["selected"]
 
+        with maintained_selection(
+            # exclude from selection, since we will be recreating the node
+            # which will invalidate the reference to the object in memory
+            exclude_nodes=[camera_node],
+        ):
             # collect input output dependencies
             dependencies = camera_node.dependencies()
             dependent = camera_node.dependent()
@@ -161,6 +165,7 @@ class AlembicCameraLoader(load.LoaderPlugin):
             # not adding animation keys properly
             xpos = camera_node.xpos()
             ypos = camera_node.ypos()
+            camera_node.selectOnly()
             nuke.nodeCopy("%clipboard%")
             camera_name = camera_node.name()
             nuke.delete(camera_node)
@@ -177,6 +182,8 @@ class AlembicCameraLoader(load.LoaderPlugin):
                               d.dependencies())
                               if camera_node is dpcy), 0)
                 d.setInput(index, camera_node)
+
+        camera_node["selected"].setValue(selected)
 
         # color node by correct color by actual version
         self.node_version_color(


### PR DESCRIPTION
## Changelog Description
fix an issue where updating cameras could cause other nodes to be copied or fail if the depending on the current seleciton

## Additional review information

alternative solution: We remove the copy/paste workaround.
I'm not sure what exactly the workaround is for, so I cannot comment on it


## Testing notes 1):
1. import a camera
1. select the camera node
2. open the  "AYON Scene Inventory"
3. change the version
3. observe a `A PythonObject is not attached to a node.` exeption
```
Version update to 'v008' failed with the following error:
A PythonObject is not attached to a node.
```
<img width="702" height="463" alt="image" src="https://github.com/user-attachments/assets/61448192-96ce-44d9-9e1f-ab1c48ea0407" />

### Explanation:

the `maintained_selection` context stores a list of selected nodes, including the camera node that is being updated
lines 164-167 cuts and pastes the node invalidating the python object referenced in the context manager
https://github.com/ynput/ayon-nuke/blob/fb4ee9b3281430d9aaca14fd9205e6439db578b9/client/ayon_nuke/plugins/load/load_camera.py#L164-L167

### How this PR fixes it:

- we exclude the camera from the `maintained_selection` https://github.com/straylondon/ayon-nuke/blob/8939f315289acdebe39a9cba50ca01f5eb4bf503/client/ayon_nuke/plugins/load/load_camera.py#L153-L155
- and manually track its "selected" state https://github.com/straylondon/ayon-nuke/blob/8939f315289acdebe39a9cba50ca01f5eb4bf503/client/ayon_nuke/plugins/load/load_camera.py#L150 https://github.com/straylondon/ayon-nuke/blob/8939f315289acdebe39a9cba50ca01f5eb4bf503/client/ayon_nuke/plugins/load/load_camera.py#L186



## Testing notes 2):
1. import a camera
1. select any other nodes
2. open the  "AYON Scene Inventory"
3. change the version 
4. the other nodes will be copy/pasted

https://github.com/user-attachments/assets/ec832675-f4fd-4015-bd24-40feccedbf56

### Explanation:

- line 151 adds the camera to the selection, but does not deselect anything https://github.com/ynput/ayon-nuke/blob/fb4ee9b3281430d9aaca14fd9205e6439db578b9/client/ayon_nuke/plugins/load/load_camera.py#L151
- again, lines 164-167: `nuke.nodeCopy("%clipboard%")` copies whatever is currently selected

### How this PR fixes it:

using `node.selectOnly()` to ensure the camera is the only object getting copied
https://github.com/straylondon/ayon-nuke/blob/8939f315289acdebe39a9cba50ca01f5eb4bf503/client/ayon_nuke/plugins/load/load_camera.py#L168


