### PR TITLE
fix(select_nodes): Safe-guard if previously selected node cannot be reselected

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2546,7 +2546,10 @@ def select_nodes(nodes):
         "nodes has to be list, tuple or set"
 
     for node in nodes:
-        node["selected"].setValue(True)
+        try:
+            node["selected"].setValue(True)
+        except Exception as error:
+            log.warning(f"Failed to select node: {error}")
 
 
 def launch_workfiles_app():

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2480,9 +2480,13 @@ def maintained_selection(exclude_nodes=None):
         # unselect all selection in case there is some
         reset_selection()
 
-        # and select all previously selected nodes
-        if previous_selection:
-            select_nodes(previous_selection)
+        for node in previous_selection:
+            try:
+                node["selected"].setValue(True)
+            except ValueError:
+                # Could fail if a node was deleted during the context.
+                # See: https://github.com/ynput/ayon-nuke/pull/331 for details.
+                pass
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Changelog Description
avoid crashing if a node cannot be selected


## Additional review information
as mentioned in https://github.com/ynput/ayon-nuke/pull/329, there can be cases where `select_nodes` may get called with a list of invalid nodes. For example when using a `maintained_selection` context manager and one of the previous selected nodes got deleted within the block.

## Testing notes:
```py
from ayon_nuke.api.lib import maintained_selection, reset_selection, select_nodes


nuke.scriptClear(force=True)

# create some test nodes
grade = nuke.createNode("Grade")
blur = nuke.createNode("Blur")
read = nuke.createNode("Read")
write = nuke.createNode("Write")

# preprare a selection
reset_selection()
select_nodes([grade, blur, read])  # select a subset

with maintained_selection():
    select_nodes([write])  # change the selection
    nuke.delete(blur)  # delete one of the selected nodes


selected_nodes = nuke.selectedNodes()
print("selected_nodes", selected_nodes)  # should be grade + read
assert len(selected_nodes) == 2
assert grade in selected_nodes
assert read in selected_nodes
assert write not in selected_nodes
```


