### PR TITLE
Opening autosave file only happened in GUI mode.

### DIFF
--- a/client/ayon_nuke/api/utils.py
+++ b/client/ayon_nuke/api/utils.py
@@ -89,14 +89,6 @@ def bake_gizmos_recursively(in_group=None):
                     bake_gizmos_recursively(node)
 
 
-def is_headless() -> bool:
-    """
-    Returns:
-        bool: headless
-    """
-    return QtWidgets.QApplication.instance() is None
-
-
 def submit_render_on_farm(node):
     # Ensure code is executed in root context.
     if nuke.root() == nuke.thisNode():

--- a/client/ayon_nuke/api/utils.py
+++ b/client/ayon_nuke/api/utils.py
@@ -4,7 +4,6 @@ import nuke
 
 import pyblish.util
 import pyblish.api
-from qtpy import QtWidgets
 
 from ayon_core import resources
 from ayon_core.pipeline import registered_host

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -2,7 +2,6 @@
 import os
 import nuke
 import shutil
-from .utils import is_headless
 from .constants import ASSIST
 
 
@@ -41,7 +40,7 @@ def open_file(filepath):
     # Nuke Preferences can be read after the script is read.
     read_script(filepath)
 
-    if not is_headless():
+    if nuke.GUI:
         autosave = nuke.toNode("preferences")["AutoSaveName"].evaluate()
         autosave_prmpt = "Autosave detected.\n" \
                          "Would you like to load the autosave file?"  # noqa


### PR DESCRIPTION
## Changelog Description
This PR is to make sure opening autosave file and autosave file popup dialog only shown when Nuke is in GUI mode.

## Additional review information
```python
import subprocess
import tempfile

from ayon_applications import ApplicationManager, LaunchTypes


def _get_python_script() -> str:
    with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as _file:
        nuke_script = "path/to/your/nuke/script.nk"  # TODO: change this
        _file.write(
            f"""
from ayon_core.pipeline import registered_host
nuke_host = registered_host()
nuke_host.open_file("{nuke_script}")
            """
        ).format(nuke_script=nuke_script)
        return _file.name


def _run_nuke_terminal_mode(python_script: str):
    app_manager = ApplicationManager()
    app_group = app_manager.app_groups["nuke"]
    app = app_manager.find_latest_available_variant_for_group(
        app_group.name
    )
    app_args = ["-t", python_script]
    context_kwargs = {
        "project_name": "Dummy",  # TODO: change this
        "folder_path": "/all_shots/edit_sequence/sh010",   # TODO: change this
        "task_name": "Compositing",   # TODO: change this
        "task_type": "Compositing",   # TODO: change this
        "app_args": app_args or [],
        "launch_type": LaunchTypes.automated,
    }

    launch_context = app_manager.create_launch_context(
        app.full_name,
        **context_kwargs,
    )
    launch_context.run_prelaunch_hooks()
    launch_args = launch_context.launch_args
    kwargs = launch_context.kwargs
    kwargs.update({
        "stdout": subprocess.PIPE,
        "stderr": subprocess.STDOUT,
        "text": True,
        "encoding": "utf-8",
        "errors": "replace",
    })

    process = subprocess.Popen(launch_args, **kwargs)
    process.wait()
    out = process.stdout.read()

    print(out)
    assert "current host name: nuke" in out, "Nuke host is not initialized."


# Run Nuke in terminal mode.
pscript_path = _get_python_script()
_run_nuke_terminal_mode(pscript_path)
```
## Testing notes:
1. Go to Ayon console
2. Perform this script
3. Should be opened without autosave popup.
