### PR TITLE
[YN-0943]: Add slate generation as a Nuke instance attribute

### DIFF
--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -459,6 +459,14 @@ class NukeWriteCreator(NukeCreator):
                     label="Review"
                 )
             )
+        if "slate_gen" in self.instance_attributes:
+            attr_defs.append(
+                BoolDef(
+                    "slate_gen",
+                    default=True,
+                    label="Slate Generation"
+                )
+            )
 
         return attr_defs
 

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -1,10 +1,10 @@
 import os
-import nuke
+
 import pyblish.api
-
 from ayon_core.pipeline import publish
-
 from ayon_nuke import api as napi
+
+import nuke  # noqa
 
 
 class CollectNukeWrites(pyblish.api.InstancePlugin,
@@ -23,12 +23,18 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
     _frame_ranges = {}
 
     def process(self, instance):
-
         # compatibility. This is mainly focused on `renders`folders which
         # were previously not cleaned up (and could be used in read notes)
         # this logic should be removed and replaced with custom staging dir
         if instance.data.get("stagingDir_persistent") is None:
             instance.data["stagingDir_persistent"] = True
+
+        # add slate family to instance.data["families"]
+        if instance.data.get("slate_gen"):
+            if instance.data.get("families") is None:
+                instance.data["families"] = []
+            instance.data["families"] = list(
+                set(instance.data["families"] + ["slate"]))
 
         group_node = instance.data["transientData"]["node"]
 
@@ -314,6 +320,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             "tags": []
         }
 
+        if instance.data.get("slate_gen"):
+            representation["tags"].append("slate-frame")
+
         if len(collected_frames) == 1:
             representation['files'] = collected_frames.pop()
         else:
@@ -353,6 +362,8 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             list: collected frames
         """
         if "slate" not in instance.data["families"]:
+            return collected_frames
+        if instance.data.get("slate_gen"):
             return collected_frames
 
         write_node = self._write_node_helper(instance)

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -375,6 +375,8 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         """
         if "slate" not in instance.data["families"]:
             return collected_frames
+        # slate_gen mode does not need to prepend slate frame
+        # since it will be created later on downstream
         if instance.data.get("slate_gen"):
             return collected_frames
 

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -107,10 +107,21 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         write_file_path = nuke.filename(write_node)
         output_dir = os.path.dirname(write_file_path)
 
-        instance.data["expectedFiles"] = [
+        expected_files = [
             os.path.join(output_dir, source_file)
             for source_file in collected_frames
         ]
+
+        # When slate generation is enabled, include the expected slate frame
+        # path so the farm integration knows to expect it.
+        if instance.data.get("slate_gen"):
+            first_frame, _ = self._get_frame_range_data(instance)
+            slate_first_frame = first_frame - 1
+            expected_slate_path = write_node["file"].evaluate(slate_first_frame)
+            if expected_slate_path not in expected_files:
+                expected_files.insert(0, expected_slate_path)
+
+        instance.data["expectedFiles"] = expected_files
 
     def _get_frame_range_data(self, instance):
         """Get frame range data from instance.

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -117,7 +117,8 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         if instance.data.get("slate_gen"):
             first_frame, _ = self._get_frame_range_data(instance)
             slate_first_frame = first_frame - 1
-            expected_slate_path = write_node["file"].evaluate(slate_first_frame)
+            expected_slate_path = write_node["file"].evaluate(
+                slate_first_frame)
             if expected_slate_path not in expected_files:
                 expected_files.insert(0, expected_slate_path)
 

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -30,11 +30,11 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             instance.data["stagingDir_persistent"] = True
 
         # add slate family to instance.data["families"]
-        if instance.data.get("slate_gen"):
-            if instance.data.get("families") is None:
-                instance.data["families"] = []
-            instance.data["families"] = list(
-                set(instance.data["families"] + ["slate"]))
+        if (
+            instance.data.get("slate_gen")
+            and "slate" not in instance.data["families"]
+        ):
+            instance.data["families"].append("slate")
 
         group_node = instance.data["transientData"]["node"]
 

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -373,6 +373,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         if (
             os.path.exists(expected_slate_path)
             or (
+                # When submitting to farm using existing frames on disk
+                # and slate generation is enabled then ensure to add
+                # the slate frame even though it may not exist yet
                 instance.data["render_target"] == "frames_farm"
                 and instance.data.get("slate_gen")
             )

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -406,6 +406,13 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         })
         self.log.info("Farm rendering ON ...")
 
+        if instance.data.get("slate_gen"):
+            write_node = self._write_node_helper(instance)
+            slate_representation_ext = instance.data.setdefault(
+                "slateRepresentationExt", [])
+            slate_representation_ext.append(
+                write_node["file_type"].value())
+
     def _get_collected_frames(self, instance):
         """Get collected frames.
 

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -112,16 +112,6 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             for source_file in collected_frames
         ]
 
-        # When slate generation is enabled, include the expected slate frame
-        # path so the farm integration knows to expect it.
-        if instance.data.get("slate_gen"):
-            first_frame, _ = self._get_frame_range_data(instance)
-            slate_first_frame = first_frame - 1
-            expected_slate_path = write_node["file"].evaluate(
-                slate_first_frame)
-            if expected_slate_path not in expected_files:
-                expected_files.insert(0, expected_slate_path)
-
         instance.data["expectedFiles"] = expected_files
 
     def _get_frame_range_data(self, instance):
@@ -375,16 +365,18 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         """
         if "slate" not in instance.data["families"]:
             return collected_frames
-        # slate_gen mode does not need to prepend slate frame
-        # since it will be created later on downstream
-        if instance.data.get("slate_gen"):
-            return collected_frames
 
         write_node = self._write_node_helper(instance)
         expected_slate_frame = first_frame - 1
         expected_slate_path = write_node["file"].evaluate(expected_slate_frame)
 
-        if os.path.exists(expected_slate_path):
+        if (
+            os.path.exists(expected_slate_path)
+            or (
+                instance.data["render_target"] == "frames_farm"
+                and instance.data.get("slate_gen")
+            )
+        ):
             slate_frame = os.path.basename(expected_slate_path)
             collected_frames.insert(0, slate_frame)
 

--- a/client/ayon_nuke/plugins/publish/extract_render_local.py
+++ b/client/ayon_nuke/plugins/publish/extract_render_local.py
@@ -124,6 +124,10 @@ class NukeRenderLocal(publish.Extractor,
                 "stagingDir": out_dir
             }
 
+        if instance.data.get("slate_gen"):
+            tags = repre.setdefault("tags", [])
+            tags.append("slate-frame")
+
         # inject colorspace data
         self.set_representation_colorspace(
             repre, instance.context,

--- a/client/ayon_nuke/plugins/publish/extract_slate_frame.py
+++ b/client/ayon_nuke/plugins/publish/extract_slate_frame.py
@@ -49,6 +49,9 @@ class ExtractSlateFrame(publish.Extractor):
         self._create_staging_dir(instance)
 
         with maintained_selection():
+            slate_node = instance.data.get("slateNode")
+            if not slate_node:
+                return
             self.log.debug("instance: {}".format(instance))
             self.log.debug("instance.data[families]: {}".format(
                 instance.data["families"]))

--- a/client/ayon_nuke/plugins/publish/extract_slate_frame.py
+++ b/client/ayon_nuke/plugins/publish/extract_slate_frame.py
@@ -300,7 +300,7 @@ class ExtractSlateFrame(publish.Extractor):
         finally:
             # Restore original slate node connections and remove temporary
             # nodes even when rendering fails.
-            if slate_node:
+            if slate_node and original_slate_input:
                 slate_node.setInput(0, original_slate_input)
             for node in temporary_nodes:
                 nuke.delete(node)

--- a/client/ayon_nuke/plugins/publish/extract_slate_frame.py
+++ b/client/ayon_nuke/plugins/publish/extract_slate_frame.py
@@ -274,21 +274,19 @@ class ExtractSlateFrame(publish.Extractor):
         # content rather than the live upstream graph.
         temporary_nodes = []
         original_slate_input = None
-        slate_node = None
-        if render_target == "frames":
+        slate_node = instance.data.get("slateNode")
+        if render_target == "frames" and slate_node:
             fpath = instance.data["path"]
-            slate_node = instance.data.get("slateNode")
-            if slate_node:
-                original_slate_input = slate_node.input(0)
-                r_node = nuke.createNode("Read")
-                r_node["file"].setValue(fpath)
-                r_node["first"].setValue(first_frame)
-                r_node["origfirst"].setValue(first_frame)
-                r_node["last"].setValue(last_frame)
-                r_node["origlast"].setValue(last_frame)
-                r_node["colorspace"].setValue(instance.data["colorspace"])
-                slate_node.setInput(0, r_node)
-                temporary_nodes.append(r_node)
+            original_slate_input = slate_node.input(0)
+            r_node = nuke.createNode("Read")
+            r_node["file"].setValue(fpath)
+            r_node["first"].setValue(first_frame)
+            r_node["origfirst"].setValue(first_frame)
+            r_node["last"].setValue(last_frame)
+            r_node["origlast"].setValue(last_frame)
+            r_node["colorspace"].setValue(instance.data["colorspace"])
+            slate_node.setInput(0, r_node)
+            temporary_nodes.append(r_node)
 
         try:
             # render slate as sequence frame

--- a/client/ayon_nuke/plugins/publish/extract_slate_frame.py
+++ b/client/ayon_nuke/plugins/publish/extract_slate_frame.py
@@ -47,15 +47,16 @@ class ExtractSlateFrame(publish.Extractor):
         if instance.data.get("farm"):
             return
 
+        slate_node = instance.data.get("slateNode")
+        if not slate_node:
+            return
+
         if "representations" not in instance.data:
             instance.data["representations"] = []
 
         self._create_staging_dir(instance)
 
         with maintained_selection():
-            slate_node = instance.data.get("slateNode")
-            if not slate_node:
-                return
             self.log.debug("instance: {}".format(instance))
             self.log.debug("instance.data[families]: {}".format(
                 instance.data["families"]))

--- a/client/ayon_nuke/plugins/publish/extract_slate_frame.py
+++ b/client/ayon_nuke/plugins/publish/extract_slate_frame.py
@@ -42,6 +42,10 @@ class ExtractSlateFrame(publish.Extractor):
     }
 
     def process(self, instance):
+        # Farm instances are rendered on the farm and slate generation
+        # will be handled server-side; skip local extraction.
+        if instance.data.get("farm"):
+            return
 
         if "representations" not in instance.data:
             instance.data["representations"] = []
@@ -249,6 +253,7 @@ class ExtractSlateFrame(publish.Extractor):
         first_frame = instance.data["frameStartHandle"]
         last_frame = instance.data["frameEndHandle"]
         slate_first_frame = first_frame - 1
+        render_target = instance.data.get("render_target", "local")
 
         # - get write node
         write_node = instance.data["transientData"]["writeNode"]
@@ -262,12 +267,40 @@ class ExtractSlateFrame(publish.Extractor):
                 write_node["use_limit"].setValue(0)
                 self.log.debug("__Setting render node limit")
 
+        # For 'existing frames' mode, the main sequence is already on disk.
+        # Connect the slate node's input to a Read node that reads the
+        # existing files so the slate is composited against already-rendered
+        # content rather than the live upstream graph.
+        temporary_nodes = []
+        original_slate_input = None
+        slate_node = None
+        if render_target == "frames":
+            fpath = instance.data["path"]
+            slate_node = instance.data.get("slateNode")
+            if slate_node:
+                original_slate_input = slate_node.input(0)
+                r_node = nuke.createNode("Read")
+                r_node["file"].setValue(fpath)
+                r_node["first"].setValue(first_frame)
+                r_node["origfirst"].setValue(first_frame)
+                r_node["last"].setValue(last_frame)
+                r_node["origlast"].setValue(last_frame)
+                r_node["colorspace"].setValue(instance.data["colorspace"])
+                slate_node.setInput(0, r_node)
+                temporary_nodes.append(r_node)
+
         # render slate as sequence frame
         nuke.execute(
             instance.data["name"],
             int(slate_first_frame),
             int(slate_first_frame)
         )
+
+        # Restore original slate node connections and remove temporary nodes
+        if slate_node and original_slate_input is not None:
+            slate_node.setInput(0, original_slate_input)
+        for node in temporary_nodes:
+            nuke.delete(node)
 
         # turn the frame range limit back on
         if limit_on:

--- a/client/ayon_nuke/plugins/publish/extract_slate_frame.py
+++ b/client/ayon_nuke/plugins/publish/extract_slate_frame.py
@@ -289,22 +289,24 @@ class ExtractSlateFrame(publish.Extractor):
                 slate_node.setInput(0, r_node)
                 temporary_nodes.append(r_node)
 
-        # render slate as sequence frame
-        nuke.execute(
-            instance.data["name"],
-            int(slate_first_frame),
-            int(slate_first_frame)
-        )
+        try:
+            # render slate as sequence frame
+            nuke.execute(
+                instance.data["name"],
+                int(slate_first_frame),
+                int(slate_first_frame)
+            )
+        finally:
+            # Restore original slate node connections and remove temporary
+            # nodes even when rendering fails.
+            if slate_node:
+                slate_node.setInput(0, original_slate_input)
+            for node in temporary_nodes:
+                nuke.delete(node)
 
-        # Restore original slate node connections and remove temporary nodes
-        if slate_node and original_slate_input is not None:
-            slate_node.setInput(0, original_slate_input)
-        for node in temporary_nodes:
-            nuke.delete(node)
-
-        # turn the frame range limit back on
-        if limit_on:
-            write_node["use_limit"].setValue(1)
+            # turn the frame range limit back on
+            if limit_on:
+                write_node["use_limit"].setValue(1)
 
         # Add file to representation files
         # - evaluate filepaths for first frame and slate frame

--- a/client/ayon_nuke/plugins/publish/extract_slate_frame.py
+++ b/client/ayon_nuke/plugins/publish/extract_slate_frame.py
@@ -254,7 +254,7 @@ class ExtractSlateFrame(publish.Extractor):
         first_frame = instance.data["frameStartHandle"]
         last_frame = instance.data["frameEndHandle"]
         slate_first_frame = first_frame - 1
-        render_target = instance.data.get("render_target", "local")
+        render_target = instance.data["render_target"]
 
         # - get write node
         write_node = instance.data["transientData"]["writeNode"]

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -21,7 +21,8 @@ INSTANCE_ATTRIBUTES_DESCRIPTION: str = (
         render of the write node to the farm **without** triggering the
         regular publish logic. This is useful for quick test renders.
     - Slate Generation: When enabled, a slate frame is generated and
-        prepended to the rendered sequence before publishing.
+        prepended to the rendered sequence before publishing. 
+        Slater addon is required
     """
 )
 

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -20,6 +20,8 @@ INSTANCE_ATTRIBUTES_DESCRIPTION: str = (
     - Render On Farm: Adds a button on the Nuke node that will submit the
         render of the write node to the farm **without** triggering the
         regular publish logic. This is useful for quick test renders.
+    - Slate Generation: When enabled, a slate frame is generated and
+        prepended to the rendered sequence before publishing.
     """
 )
 

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -8,7 +8,6 @@ from .common import KnobModel
 
 INSTANCE_ATTRIBUTES_DESCRIPTION: str = (
     """Allows to enable or disable certain features for the instance:
-
     - Reviewable: Mark the output as reviewable, allowing transcoding and
         e.g. uploading as reviewable to production tracker (depending on
         what tags are sets for reviewables)
@@ -41,10 +40,8 @@ def instance_attributes_enum():
         {"value": "reviewable", "label": "Reviewable"},
         {"value": "farm_rendering", "label": "Farm rendering"},
         {"value": "use_range_limit", "label": "Use range limit"},
-        {
-            "value": "render_on_farm",
-            "label": "Render On Farm"
-        }
+        {"value": "render_on_farm", "label": "Render On Farm"},
+        {"value": "slate_gen", "label": "Slate Generation"}
     ]
 
 

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -21,7 +21,7 @@ INSTANCE_ATTRIBUTES_DESCRIPTION: str = (
         render of the write node to the farm **without** triggering the
         regular publish logic. This is useful for quick test renders.
     - Slate Generation: When enabled, a slate frame is generated and
-        prepended to the rendered sequence before publishing. 
+        prepended to the rendered sequence before publishing.
         Slater addon is required
     """
 )


### PR DESCRIPTION
## Changelog Description

Adds a new **slate_gen** instance attribute ("Slate Generation", default `True`) to the Nuke writer plugin. When enabled on an instance, slate generation is triggered as part of the write workflow. The definition joins existing options (Reviewable, Farm rendering, Use range limit, Render On Farm) in one place and is consumed by both client and server sides.

## Additional info

N/A

## Testing notes:

1. Create a Nuke Write instance with Slate Generation enabled (default). Verify the attribute appears correctly in the server UI and on the client side.
2. Create another instance with Slate Generation disabled and confirm workflow behavior matches expectations.

## Dependency
Need to be tested with: https://github.com/ynput/ayon-core/pull/1965
Close https://github.com/ynput/ayon-nuke/issues/333

## Related support tickets

[YN-0943](https://support.ayon.app/projects/Active_Clients/overview/projects/Active_Clients/overview/projects/Active_Clients?project=Active_Clients&type=task&id=f2d9f886affb455a9dbaa9ecc0221cca)