### PR TITLE
Add the options to enable context and its related settings

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2089,9 +2089,6 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
     def set_colorspace(self):
         """Setting colorspace following presets
         """
-        if not self._settings_to_apply.get("colorspace_settings", True):
-            log.info("Colorspace settings are disabled in project settings.")
-            return
         # get imageio
         nuke_colorspace = get_nuke_imageio_settings()
 
@@ -2123,10 +2120,6 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
 
     def reset_frame_range_handles(self):
         """Set frame range to current folder."""
-        if not self._settings_to_apply.get("frame_range_settings", True):
-            log.info("Frame range settings are disabled in project settings.")
-            return
-
         if "attrib" not in self._task_entity:
             msg = "Task {} doesn't have set any 'attrib'".format(
                 self._context_label
@@ -2197,9 +2190,6 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
 
     def reset_resolution(self):
         """Set resolution to project resolution."""
-        if not self._settings_to_apply.get("resolution_settings", True):
-            log.info("Resolution settings are disabled in project settings.")
-            return
         log.info("Resetting resolution")
         project_name = get_current_project_name()
         task_attributes = self._task_entity["attrib"]
@@ -2272,11 +2262,8 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
                 "{name}".format(**kwargs)
             )
 
-    def set_context_settings(self, enabled_on_callback=True):
+    def set_context_settings(self):
         """Apply context-related settings for script creation/load events."""
-        if not enabled_on_callback:
-            log.info("Context settings are disabled in project settings.")
-            return
         self.reset_resolution()
         self.reset_frame_range_handles()
         # add colorspace menu item

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -2120,6 +2120,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
 
     def reset_frame_range_handles(self):
         """Set frame range to current folder."""
+
         if "attrib" not in self._task_entity:
             msg = "Task {} doesn't have set any 'attrib'".format(
                 self._context_label
@@ -2263,7 +2264,6 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
             )
 
     def set_context_settings(self):
-        """Apply context-related settings for script creation/load events."""
         self.reset_resolution()
         self.reset_frame_range_handles()
         # add colorspace menu item

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1562,6 +1562,10 @@ class WorkfileSettings(object):
             project_name, self._folder_path, self._task_name, "nuke"
         )
         self.formatting_data = context_data
+        self._settings_to_apply = (
+            get_project_settings(project_name)["nuke"]["general"].get(
+                "settings_to_apply", {})
+        )
 
     def get_nodes(self, nodes=None, nodes_filter=None):
 
@@ -2089,6 +2093,9 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
     def set_colorspace(self):
         """Setting colorspace following presets
         """
+        if not self._settings_to_apply.get("colorspace_settings", True):
+            log.info("Colorspace settings are disabled in project settings.")
+            return
         # get imageio
         nuke_colorspace = get_nuke_imageio_settings()
 
@@ -2120,6 +2127,9 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
 
     def reset_frame_range_handles(self):
         """Set frame range to current folder."""
+        if not self._settings_to_apply.get("frame_range_settings", True):
+            log.info("Frame range settings are disabled in project settings.")
+            return
 
         if "attrib" not in self._task_entity:
             msg = "Task {} doesn't have set any 'attrib'".format(
@@ -2191,6 +2201,9 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
 
     def reset_resolution(self):
         """Set resolution to project resolution."""
+        if not self._settings_to_apply.get("resolution_settings", True):
+            log.info("Resolution settings are disabled in project settings.")
+            return
         log.info("Resetting resolution")
         project_name = get_current_project_name()
         task_attributes = self._task_entity["attrib"]
@@ -2263,7 +2276,14 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
                 "{name}".format(**kwargs)
             )
 
-    def set_context_settings(self):
+    def set_context_settings(self, enabled_on_callback=True):
+        """Apply context-related settings for script creation/load events."""
+        if not (
+            self._settings_to_apply.get("context_settings", True)
+            or enabled_on_callback
+        ):
+            log.info("Context settings are disabled in project settings.")
+            return
         self.reset_resolution()
         self.reset_frame_range_handles()
         # add colorspace menu item

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1562,10 +1562,6 @@ class WorkfileSettings(object):
             project_name, self._folder_path, self._task_name, "nuke"
         )
         self.formatting_data = context_data
-        self._settings_to_apply = (
-            get_project_settings(project_name)["nuke"]["general"].get(
-                "settings_to_apply", {})
-        )
 
     def get_nodes(self, nodes=None, nodes_filter=None):
 
@@ -2278,10 +2274,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
 
     def set_context_settings(self, enabled_on_callback=True):
         """Apply context-related settings for script creation/load events."""
-        if not (
-            self._settings_to_apply.get("context_settings", True)
-            or enabled_on_callback
-        ):
+        if not enabled_on_callback:
             log.info("Context settings are disabled in project settings.")
             return
         self.reset_resolution()

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -834,16 +834,6 @@ def get_view_process_node():
         return duplicate_node(ipn_node)
 
 
-def on_script_load():
-    """Callback for ffmpeg support"""
-    if nuke.env["LINUX"]:
-        nuke.tcl('load ffmpegReader')
-        nuke.tcl('load ffmpegWriter')
-    else:
-        nuke.tcl('load movReader')
-        nuke.tcl('load movWriter')
-
-
 def check_inventory_versions():
     """Update loaded container nodes' colors based on version state.
 

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1523,7 +1523,12 @@ class WorkfileSettings(object):
 
     """
 
-    def __init__(self, root_node=None, nodes=None, **kwargs):
+    def __init__(
+            self,
+            root_node=None,
+            nodes=None,
+            project_settings=None,
+            **kwargs):
         project_entity = kwargs.get("project")
         if project_entity is None:
             project_name = get_current_project_name()
@@ -1552,6 +1557,18 @@ class WorkfileSettings(object):
             project_name, self._folder_path, self._task_name, "nuke"
         )
         self.formatting_data = context_data
+        self._project_setting = project_settings
+
+    @property
+    def project_settings(self) -> dict:
+        """Get project settings
+
+        Returns:
+            dict: project settings for the current project
+        """
+        if not self._project_setting:
+            self._project_setting = get_project_settings(self._project_name)
+        return self._project_setting
 
     def get_nodes(self, nodes=None, nodes_filter=None):
 
@@ -1645,7 +1662,9 @@ class WorkfileSettings(object):
             imageio_host (dict): host colorspace configurations
 
         """
-        config_data = get_current_context_imageio_config_preset()
+        config_data = get_current_context_imageio_config_preset(
+            project_settings=self.project_settings
+        )
 
         workfile_settings = imageio_host["workfile"]
         color_management = workfile_settings["color_management"]
@@ -1972,9 +1991,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
             # This ensures that any values overwritten by the user is
             # not changed by the colorspace knobs set.
             colorspace_knobs = nuke_imageio_writes["knobs"]
-            all_create_settings = get_project_settings(
-                Context.project_name,
-            )["nuke"]["create"]
+            all_create_settings = self.project_settings["nuke"]["create"]
             plugin_names_mapping = {
                 "create_write_image": "CreateWriteImage",
                 "create_write_prerender": "CreateWritePrerender",

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -226,11 +226,17 @@ def add_nuke_callbacks(project_settings: dict = None):
         project_settings = get_current_project_settings()
 
     nuke_settings = project_settings["nuke"]
+    settings_to_apply = nuke_settings["general"].get("settings_to_apply", {})
+
     workfile_settings = WorkfileSettings()
 
     # Set context settings.
     nuke.addOnCreate(
-        workfile_settings.set_context_settings, nodeClass="Root")
+        lambda: workfile_settings.set_context_settings(
+            enabled_on_callback=settings_to_apply.get(
+                "context_settings_on_script_create", True
+        )), nodeClass="Root"
+    )
 
     # adding favorites to file browser
     nuke.addOnCreate(workfile_settings.set_favorites, nodeClass="Root")
@@ -246,7 +252,13 @@ def add_nuke_callbacks(project_settings: dict = None):
     nuke.addOnScriptSave(check_inventory_versions)
 
     # set apply all workfile settings on script load and save
-    nuke.addOnScriptLoad(WorkfileSettings().set_context_settings)
+    nuke.addOnScriptLoad(
+        lambda: workfile_settings.set_context_settings(
+            enabled_on_callback=settings_to_apply.get(
+                "context_settings_on_script_open", True
+            )
+        )
+    )
 
     if nuke_settings["dirmap"]["enabled"]:
         log.info("Added Nuke's dir-mapping callback ...")

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -226,15 +226,19 @@ def add_nuke_callbacks(project_settings: dict = None):
         project_settings = get_current_project_settings()
 
     nuke_settings = project_settings["nuke"]
-    settings_to_apply = nuke_settings["general"].get("settings_to_apply", {})
+    workfile_callback_settings = nuke_settings.get("workfile_callbacks", {})
 
     workfile_settings = WorkfileSettings()
 
-    # Set context settings.
-    if settings_to_apply.get("context_settings_on_script_create", True):
-        nuke.addOnCreate(
-            workfile_settings.set_context_settings, nodeClass="Root"
-        )
+    # Set all workfile settings.
+    on_script_create_settings = workfile_callback_settings["on_script_create"]
+    for setting_key, func in (
+        ("resolution_from_context", workfile_settings.reset_resolution),
+        ("range_from_context", workfile_settings.reset_frame_range_handles),
+        ("colorspace_from_context", workfile_settings.set_colorspace),
+    ):
+        if on_script_create_settings.get(setting_key, True):
+            nuke.addOnCreate(func, nodeClass="Root")
 
     # adding favorites to file browser
     nuke.addOnCreate(workfile_settings.set_favorites, nodeClass="Root")
@@ -250,8 +254,14 @@ def add_nuke_callbacks(project_settings: dict = None):
     nuke.addOnScriptSave(check_inventory_versions)
 
     # set apply all workfile settings on script load and save
-    if settings_to_apply.get("context_settings_on_script_open", True):
-        nuke.addOnScriptLoad(workfile_settings.set_context_settings)
+    if workfile_callback_settings.get("on_script_open", True):
+        for setting_key, func in (
+            ("resolution_from_context", workfile_settings.reset_resolution),
+            ("range_from_context", workfile_settings.reset_frame_range_handles),
+            ("colorspace_from_context", workfile_settings.set_colorspace),
+        ):
+            if on_script_create_settings.get(setting_key, True):
+                nuke.addOnScriptLoad(func)
 
     if nuke_settings["dirmap"]["enabled"]:
         log.info("Added Nuke's dir-mapping callback ...")

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -254,7 +254,7 @@ def on_root_create() -> None:
         ["workfile_callbacks"]
         ["on_script_create"]
     )
-    
+
     if on_script_create_settings["set_resolution"]:
         workfile_settings.reset_resolution()
 

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -247,21 +247,23 @@ def add_nuke_callbacks(project_settings: dict = None):
 def on_root_create() -> None:
     """Callback function for on script create."""
     # set apply all workfile settings on script load and save
-    project_settings = get_current_project_settings()
+    workfile_settings = WorkfileSettings()
     on_script_create_settings = (
-        project_settings["nuke"]
-                        ["workfile_callbacks"]
-                        ["on_script_create"]
+        workfile_settings.project_settings
+        ["nuke"]
+        ["workfile_callbacks"]
+        ["on_script_create"]
     )
+    
+    if on_script_create_settings["set_resolution"]:
+        workfile_settings.reset_resolution()
 
-    if any(on_script_create_settings.values()):
-        workfile_settings = WorkfileSettings(project_settings=project_settings)
-        if on_script_create_settings.get("set_resolution", True):
-            workfile_settings.reset_resolution()
-        if on_script_create_settings.get("set_frame_range", True):
-            workfile_settings.reset_frame_range_handles()
-        if on_script_create_settings.get("set_colorspace", True):
-            workfile_settings.set_colorspace()
+    if on_script_create_settings["set_frame_range"]:
+        workfile_settings.reset_frame_range_handles()
+
+    if on_script_create_settings["set_colorspace"]:
+        workfile_settings.set_colorspace()
+
     # adding favorites to file browser
     workfile_settings.set_favorites()
     # template builder callbacks

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -257,7 +257,7 @@ def add_nuke_callbacks(project_settings: dict = None):
     if workfile_callback_settings.get("on_script_open", True):
         for setting_key, func in (
             ("resolution_from_context", workfile_settings.reset_resolution),
-            ("range_from_context", workfile_settings.reset_frame_range_handles),
+            ("range_from_context", workfile_settings.reset_frame_range_handles),  # noqa: E501
             ("colorspace_from_context", workfile_settings.set_colorspace),
         ):
             if on_script_create_settings.get(setting_key, True):

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -279,21 +279,22 @@ def on_root_load() -> None:
         nuke.tcl('load movWriter')
 
     # set apply all workfile settings on script load and save
-    project_settings = get_current_project_settings()
+    workfile_settings = WorkfileSettings()
     on_script_load_settings = (
-        project_settings["nuke"]
-                        ["workfile_callbacks"]
-                        ["on_script_load"]
+        workfile_settings.project_settings
+        ["nuke"]
+        ["workfile_callbacks"]
+        ["on_script_load"]
     )
 
-    if any(on_script_load_settings.values()):
-        workfile_settings = WorkfileSettings(project_settings=project_settings)
-        if on_script_load_settings.get("set_resolution", True):
-            workfile_settings.reset_resolution()
-        if on_script_load_settings.get("set_frame_range", True):
-            workfile_settings.reset_frame_range_handles()
-        if on_script_load_settings.get("set_colorspace", True):
-            workfile_settings.set_colorspace()
+    if on_script_load_settings["set_resolution"]:
+        workfile_settings.reset_resolution()
+
+    if on_script_load_settings["set_frame_range"]:
+        workfile_settings.reset_frame_range_handles()
+
+    if on_script_load_settings["set_colorspace"]:
+        workfile_settings.set_colorspace()
 
 
 def reload_config():

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -226,42 +226,14 @@ def add_nuke_callbacks(project_settings: dict = None):
         project_settings = get_current_project_settings()
 
     nuke_settings = project_settings["nuke"]
-    workfile_callback_settings = nuke_settings.get("workfile_callbacks", {})
-
-    workfile_settings = WorkfileSettings()
 
     # Set all workfile settings.
-    on_script_create_settings = workfile_callback_settings["on_script_create"]
-    for setting_key, func in (
-        ("resolution_from_context", workfile_settings.reset_resolution),
-        ("range_from_context", workfile_settings.reset_frame_range_handles),
-        ("colorspace_from_context", workfile_settings.set_colorspace),
-    ):
-        if on_script_create_settings.get(setting_key, True):
-            nuke.addOnCreate(func, nodeClass="Root")
-
-    # adding favorites to file browser
-    nuke.addOnCreate(workfile_settings.set_favorites, nodeClass="Root")
-
-    # template builder callbacks
-    nuke.addOnCreate(start_workfile_template_builder, nodeClass="Root")
-
+    nuke.addOnCreate(on_root_create, nodeClass="Root")
     # fix ffmpeg settings on script
-    nuke.addOnScriptLoad(on_script_load)
+    nuke.addOnScriptLoad(on_root_load)
 
     # set checker for last versions on loaded containers
-    nuke.addOnScriptLoad(check_inventory_versions)
     nuke.addOnScriptSave(check_inventory_versions)
-
-    # set apply all workfile settings on script load and save
-    if workfile_callback_settings.get("on_script_open", True):
-        for setting_key, func in (
-            ("resolution_from_context", workfile_settings.reset_resolution),
-            ("range_from_context", workfile_settings.reset_frame_range_handles),  # noqa: E501
-            ("colorspace_from_context", workfile_settings.set_colorspace),
-        ):
-            if on_script_create_settings.get(setting_key, True):
-                nuke.addOnScriptLoad(func)
 
     if nuke_settings["dirmap"]["enabled"]:
         log.info("Added Nuke's dir-mapping callback ...")
@@ -269,6 +241,54 @@ def add_nuke_callbacks(project_settings: dict = None):
         nuke.addFilenameFilter(dirmap_file_name_filter)
 
     log.info("Added Nuke callbacks ...")
+
+
+def on_root_create() -> None:
+    """Callback function for on script create."""
+    # set apply all workfile settings on script load and save
+    project_settings = get_current_project_settings()
+    on_script_create_settings = (
+        project_settings["nuke"]
+                        ["workfile_callbacks"]
+                        ["on_script_create"]
+    )
+
+    if any(on_script_create_settings.values()):
+        workfile_settings = WorkfileSettings(project_settings=project_settings)
+        if on_script_create_settings.get("resolution_from_context", True):
+            workfile_settings.reset_resolution()
+        if on_script_create_settings.get("frame_range_from_context", True):
+            workfile_settings.reset_frame_range_handles()
+        if on_script_create_settings.get("colorspace_from_context", True):
+            workfile_settings.set_colorspace()
+    # adding favorites to file browser
+    workfile_settings.set_favorites()
+    # template builder callbacks
+    start_workfile_template_builder()
+
+
+def on_root_load() -> None:
+    """Callback function for on script load."""
+    # fix ffmpeg settings on script
+    on_script_load()
+    # set checker for last versions on loaded containers
+    check_inventory_versions()
+    # set apply all workfile settings on script load and save
+    project_settings = get_current_project_settings()
+    on_script_load_settings = (
+        project_settings["nuke"]
+                        ["workfile_callbacks"]
+                        ["on_script_load"]
+    )
+
+    if any(on_script_load_settings.values()):
+        workfile_settings = WorkfileSettings(project_settings=project_settings)
+        if on_script_load_settings.get("resolution_from_context", True):
+            workfile_settings.reset_resolution()
+        if on_script_load_settings.get("frame_range_from_context", True):
+            workfile_settings.reset_frame_range_handles()
+        if on_script_load_settings.get("colorspace_from_context", True):
+            workfile_settings.set_colorspace()
 
 
 def reload_config():

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -231,12 +231,10 @@ def add_nuke_callbacks(project_settings: dict = None):
     workfile_settings = WorkfileSettings()
 
     # Set context settings.
-    nuke.addOnCreate(
-        lambda: workfile_settings.set_context_settings(
-            enabled_on_callback=settings_to_apply.get(
-                "context_settings_on_script_create", True
-        )), nodeClass="Root"
-    )
+    if settings_to_apply.get("context_settings_on_script_create", True):
+        nuke.addOnCreate(
+            workfile_settings.set_context_settings, nodeClass="Root"
+        )
 
     # adding favorites to file browser
     nuke.addOnCreate(workfile_settings.set_favorites, nodeClass="Root")
@@ -252,13 +250,8 @@ def add_nuke_callbacks(project_settings: dict = None):
     nuke.addOnScriptSave(check_inventory_versions)
 
     # set apply all workfile settings on script load and save
-    nuke.addOnScriptLoad(
-        lambda: workfile_settings.set_context_settings(
-            enabled_on_callback=settings_to_apply.get(
-                "context_settings_on_script_open", True
-            )
-        )
-    )
+    if settings_to_apply.get("context_settings_on_script_open", True):
+        nuke.addOnScriptLoad(workfile_settings.set_context_settings)
 
     if nuke_settings["dirmap"]["enabled"]:
         log.info("Added Nuke's dir-mapping callback ...")

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -58,7 +58,6 @@ from .lib import (
     check_inventory_versions,
     set_avalon_knob_data,
     read_avalon_data,
-    on_script_load,
     prompt_reset_context,
     dirmap_file_name_filter,
     add_scripts_menu,
@@ -227,8 +226,10 @@ def add_nuke_callbacks(project_settings: dict = None):
 
     nuke_settings = project_settings["nuke"]
 
-    # Set all workfile settings.
+    # Set all workfile settings.'
     nuke.addOnCreate(on_root_create, nodeClass="Root")
+    # set checker for last versions on loaded containers
+    nuke.addOnScriptLoad(check_inventory_versions)
     # fix ffmpeg settings on script
     nuke.addOnScriptLoad(on_root_load)
 
@@ -270,9 +271,13 @@ def on_root_create() -> None:
 def on_root_load() -> None:
     """Callback function for on script load."""
     # fix ffmpeg settings on script
-    on_script_load()
-    # set checker for last versions on loaded containers
-    check_inventory_versions()
+    if nuke.env["LINUX"]:
+        nuke.tcl('load ffmpegReader')
+        nuke.tcl('load ffmpegWriter')
+    else:
+        nuke.tcl('load movReader')
+        nuke.tcl('load movWriter')
+
     # set apply all workfile settings on script load and save
     project_settings = get_current_project_settings()
     on_script_load_settings = (

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -231,7 +231,7 @@ def add_nuke_callbacks(project_settings: dict = None):
     # set checker for last versions on loaded containers
     nuke.addOnScriptLoad(check_inventory_versions)
     # fix ffmpeg settings on script
-    nuke.addOnScriptLoad(on_root_load)
+    nuke.addOnScriptLoad(on_script_load)
 
     # set checker for last versions on loaded containers
     nuke.addOnScriptSave(check_inventory_versions)
@@ -270,7 +270,7 @@ def on_root_create() -> None:
     start_workfile_template_builder()
 
 
-def on_root_load() -> None:
+def on_script_load() -> None:
     """Callback function for on script load."""
     # fix ffmpeg settings on script
     if nuke.env["LINUX"]:

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -256,11 +256,11 @@ def on_root_create() -> None:
 
     if any(on_script_create_settings.values()):
         workfile_settings = WorkfileSettings(project_settings=project_settings)
-        if on_script_create_settings.get("resolution_from_context", True):
+        if on_script_create_settings.get("set_resolution", True):
             workfile_settings.reset_resolution()
-        if on_script_create_settings.get("frame_range_from_context", True):
+        if on_script_create_settings.get("set_frame_range", True):
             workfile_settings.reset_frame_range_handles()
-        if on_script_create_settings.get("colorspace_from_context", True):
+        if on_script_create_settings.get("set_colorspace", True):
             workfile_settings.set_colorspace()
     # adding favorites to file browser
     workfile_settings.set_favorites()
@@ -288,11 +288,11 @@ def on_root_load() -> None:
 
     if any(on_script_load_settings.values()):
         workfile_settings = WorkfileSettings(project_settings=project_settings)
-        if on_script_load_settings.get("resolution_from_context", True):
+        if on_script_load_settings.get("set_resolution", True):
             workfile_settings.reset_resolution()
-        if on_script_load_settings.get("frame_range_from_context", True):
+        if on_script_load_settings.get("set_frame_range", True):
             workfile_settings.reset_frame_range_handles()
-        if on_script_load_settings.get("colorspace_from_context", True):
+        if on_script_load_settings.get("set_colorspace", True):
             workfile_settings.set_colorspace()
 
 

--- a/server/settings/general.py
+++ b/server/settings/general.py
@@ -1,6 +1,34 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
+class SettingsToApply(BaseSettingsModel):
+    """Settings to apply in Nuke."""
+    context_settings_on_script_create: bool = SettingsField(
+        default=True,
+        title="Apply context settings on script create",
+    )
+    context_settings_on_script_open: bool = SettingsField(
+        default=True,
+        title="Apply context settings on script open",
+    )
+    context_settings: bool = SettingsField(
+        default=True,
+        title="Apply context settings",
+    )
+    frame_range_settings: bool = SettingsField(
+        default=True,
+        title="Apply frame range settings",
+    )
+    resolution_settings: bool = SettingsField(
+        default=True,
+        title="Apply resolution settings",
+    )
+    colorspace_settings: bool = SettingsField(
+        default=True,
+        title="Apply colorspace settings",
+    )
+
+
 class MenuShortcut(BaseSettingsModel):
     """Nuke general project settings."""
 
@@ -26,7 +54,10 @@ class MenuShortcut(BaseSettingsModel):
 
 class GeneralSettings(BaseSettingsModel):
     """Nuke general project settings."""
-
+    settings_to_apply: SettingsToApply = SettingsField(
+        default_factory=SettingsToApply,
+        title="Settings to apply",
+    )
     menu: MenuShortcut = SettingsField(
         default_factory=MenuShortcut,
         title="Menu Shortcuts",
@@ -34,6 +65,14 @@ class GeneralSettings(BaseSettingsModel):
 
 
 DEFAULT_GENERAL_SETTINGS = {
+    "settings_to_apply": {
+        "context_settings_on_script_create": True,
+        "context_settings_on_script_open": True,
+        "context_settings": True,
+        "frame_range_settings": True,
+        "resolution_settings": True,
+        "colorspace_settings": True,
+    },
     "menu": {
         "create": "ctrl+alt+c",
         "publish": "ctrl+alt+p",

--- a/server/settings/general.py
+++ b/server/settings/general.py
@@ -11,18 +11,6 @@ class SettingsToApply(BaseSettingsModel):
         default=True,
         title="Apply context settings on script open",
     )
-    frame_range_settings: bool = SettingsField(
-        default=True,
-        title="Apply frame range settings",
-    )
-    resolution_settings: bool = SettingsField(
-        default=True,
-        title="Apply resolution settings",
-    )
-    colorspace_settings: bool = SettingsField(
-        default=True,
-        title="Apply colorspace settings",
-    )
 
 
 class MenuShortcut(BaseSettingsModel):
@@ -64,9 +52,6 @@ DEFAULT_GENERAL_SETTINGS = {
     "settings_to_apply": {
         "context_settings_on_script_create": True,
         "context_settings_on_script_open": True,
-        "frame_range_settings": True,
-        "resolution_settings": True,
-        "colorspace_settings": True,
     },
     "menu": {
         "create": "ctrl+alt+c",

--- a/server/settings/general.py
+++ b/server/settings/general.py
@@ -11,10 +11,6 @@ class SettingsToApply(BaseSettingsModel):
         default=True,
         title="Apply context settings on script open",
     )
-    context_settings: bool = SettingsField(
-        default=True,
-        title="Apply context settings",
-    )
     frame_range_settings: bool = SettingsField(
         default=True,
         title="Apply frame range settings",
@@ -68,7 +64,6 @@ DEFAULT_GENERAL_SETTINGS = {
     "settings_to_apply": {
         "context_settings_on_script_create": True,
         "context_settings_on_script_open": True,
-        "context_settings": True,
         "frame_range_settings": True,
         "resolution_settings": True,
         "colorspace_settings": True,

--- a/server/settings/general.py
+++ b/server/settings/general.py
@@ -1,18 +1,6 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
-class SettingsToApply(BaseSettingsModel):
-    """Settings to apply in Nuke."""
-    context_settings_on_script_create: bool = SettingsField(
-        default=True,
-        title="Apply context settings on script create",
-    )
-    context_settings_on_script_open: bool = SettingsField(
-        default=True,
-        title="Apply context settings on script open",
-    )
-
-
 class MenuShortcut(BaseSettingsModel):
     """Nuke general project settings."""
 
@@ -38,10 +26,6 @@ class MenuShortcut(BaseSettingsModel):
 
 class GeneralSettings(BaseSettingsModel):
     """Nuke general project settings."""
-    settings_to_apply: SettingsToApply = SettingsField(
-        default_factory=SettingsToApply,
-        title="Settings to apply",
-    )
     menu: MenuShortcut = SettingsField(
         default_factory=MenuShortcut,
         title="Menu Shortcuts",
@@ -49,10 +33,6 @@ class GeneralSettings(BaseSettingsModel):
 
 
 DEFAULT_GENERAL_SETTINGS = {
-    "settings_to_apply": {
-        "context_settings_on_script_create": True,
-        "context_settings_on_script_open": True,
-    },
     "menu": {
         "create": "ctrl+alt+c",
         "publish": "ctrl+alt+p",

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -7,6 +7,10 @@ from .general import (
     GeneralSettings,
     DEFAULT_GENERAL_SETTINGS
 )
+from .workfile_callbacks import (
+    WorkfileCallbacks,
+    DEFAULT_WORKFILE_CALLBACKS_SETTINGS
+)
 from .imageio import (
     ImageIOSettings,
     DEFAULT_IMAGEIO_SETTINGS
@@ -50,6 +54,11 @@ class NukeSettings(BaseSettingsModel):
     general: GeneralSettings = SettingsField(
         default_factory=GeneralSettings,
         title="General",
+    )
+
+    workfile_callbacks: WorkfileCallbacks = SettingsField(
+        default_factory=WorkfileCallbacks,
+        title="Workfile Callbacks",
     )
 
     imageio: ImageIOSettings = SettingsField(
@@ -98,6 +107,7 @@ class NukeSettings(BaseSettingsModel):
 
 DEFAULT_VALUES = {
     "general": DEFAULT_GENERAL_SETTINGS,
+    "workfile_callbacks": DEFAULT_WORKFILE_CALLBACKS_SETTINGS,
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
     "dirmap": DEFAULT_DIRMAP_SETTINGS,
     "scriptsmenu": DEFAULT_SCRIPTSMENU_SETTINGS,

--- a/server/settings/workfile_callbacks.py
+++ b/server/settings/workfile_callbacks.py
@@ -1,21 +1,48 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
+class ContextSettings(BaseSettingsModel):
+    """Nuke context settings."""
+
+    resolution_from_context: bool = SettingsField(
+        default=True,
+        title="Resolution from Context",
+        description="Set resolution from context on new workfile.",
+    )
+    frame_range_from_context: bool = SettingsField(
+        default=True,
+        title="Frame Range from Context",
+        description="Set frame range from context on new workfile.",
+    )
+    colorspace_from_context: bool = SettingsField(
+        default=True,
+        title="Colorspace from Context",
+        description="Set colorspace from context on new workfile.",
+    )
+
 
 class WorkfileCallbacks(BaseSettingsModel):
     """Callbacks to apply in Nuke."""
-    on_script_create: bool = SettingsField(
-        default=True,
+    on_script_create: ContextSettings = SettingsField(
+        default_factory=ContextSettings,
         title="On Script Create",
         description="Apply callbacks from AYON context on new workfile",
     )
-    on_script_open: bool = SettingsField(
-        default=True,
+    on_script_open: ContextSettings = SettingsField(
+        default_factory=ContextSettings,
         title="On Script Open",
         description="Apply callbacks from AYON context on loaded workfile.",
     )
 
 
 DEFAULT_WORKFILE_CALLBACKS_SETTINGS = {
-    "on_script_create": True,
-    "on_script_open": True,
+    "on_script_create": {
+        "resolution_from_context": True,
+        "frame_range_from_context": True,
+        "colorspace_from_context": True,
+    },
+    "on_script_open": {
+        "resolution_from_context": True,
+        "frame_range_from_context": True,
+        "colorspace_from_context": True,
+    },
 }

--- a/server/settings/workfile_callbacks.py
+++ b/server/settings/workfile_callbacks.py
@@ -1,0 +1,21 @@
+from ayon_server.settings import BaseSettingsModel, SettingsField
+
+
+class WorkfileCallbacks(BaseSettingsModel):
+    """Callbacks to apply in Nuke."""
+    on_script_create: bool = SettingsField(
+        default=True,
+        title="On Script Create",
+        description="Apply callbacks from AYON context on new workfile",
+    )
+    on_script_open: bool = SettingsField(
+        default=True,
+        title="On Script Open",
+        description="Apply callbacks from AYON context on loaded workfile.",
+    )
+
+
+DEFAULT_WORKFILE_CALLBACKS_SETTINGS = {
+    "on_script_create": True,
+    "on_script_open": True,
+}

--- a/server/settings/workfile_callbacks.py
+++ b/server/settings/workfile_callbacks.py
@@ -1,5 +1,6 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
+
 class ContextSettings(BaseSettingsModel):
     """Nuke context settings."""
 

--- a/server/settings/workfile_callbacks.py
+++ b/server/settings/workfile_callbacks.py
@@ -3,17 +3,17 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 class ContextSettings(BaseSettingsModel):
     """Nuke context settings."""
 
-    resolution_from_context: bool = SettingsField(
+    set_resolution: bool = SettingsField(
         default=True,
         title="Resolution from Context",
         description="Set resolution from context on new workfile.",
     )
-    frame_range_from_context: bool = SettingsField(
+    set_frame_range: bool = SettingsField(
         default=True,
         title="Frame Range from Context",
         description="Set frame range from context on new workfile.",
     )
-    colorspace_from_context: bool = SettingsField(
+    set_colorspace: bool = SettingsField(
         default=True,
         title="Colorspace from Context",
         description="Set colorspace from context on new workfile.",
@@ -36,13 +36,13 @@ class WorkfileCallbacks(BaseSettingsModel):
 
 DEFAULT_WORKFILE_CALLBACKS_SETTINGS = {
     "on_script_create": {
-        "resolution_from_context": True,
-        "frame_range_from_context": True,
-        "colorspace_from_context": True,
+        "set_resolution": True,
+        "set_frame_range": True,
+        "set_colorspace": True,
     },
     "on_script_open": {
-        "resolution_from_context": True,
-        "frame_range_from_context": True,
-        "colorspace_from_context": True,
+        "set_resolution": True,
+        "set_frame_range": True,
+        "set_colorspace": True,
     },
 }


### PR DESCRIPTION
## Changelog Description
This PR is to add the options to enable and its related settings through the addon settings.
Throughout this PR, users can also choose whether enabling to set context settings during callbacks.

## Additional review information
Marked it as draft, we need to discuss whether better designs for the setting needed for this.

## Testing notes:
1. Launch Nuke
2. Toggle the settings from `ayon+settings://nuke/general/settings_to_apply` in AYON server
