### PR TITLE
don't force evaluation of whole comp tree when searching for downstre…

### DIFF
--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -187,16 +187,10 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             "colorspace": colorspace
         }
 
-        time_warp_node = next(
-            (
-                dependent_node
-                for dependent_node in instance.data["transientData"][
-                    "node"
-                ].dependent(nuke.INPUTS, forceEvaluate=False)
-                if dependent_node.Class() == "TimeWarp"
-            ),
-            None,
+        time_warp_node = _find_downstream_time_warp_node(
+            instance.data["transientData"]["node"]
         )
+
         if time_warp_node:
             time_warp_dict = {
                 "Class": time_warp_node.Class(),
@@ -435,3 +429,8 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             collected_frames,
             first_frame
         )
+
+def _find_downstream_time_warp_node(start_node):
+    for node in start_node.dependent(nuke.INPUTS, forceEvaluate=False):
+        if node.Class() == "TimeWarp":
+            return node

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -187,8 +187,15 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             "colorspace": colorspace
         }
 
-        time_warp_node = _find_downstream_time_warp_node(
-            instance.data["transientData"]["node"]
+        time_warp_node = next(
+            (
+                dependent_node
+                for dependent_node in instance.data["transientData"][
+                    "node"
+                ].dependent(nuke.INPUTS, forceEvaluate=False)
+                if dependent_node.Class() == "TimeWarp"
+            ),
+            None,
         )
         if time_warp_node:
             time_warp_dict = {
@@ -428,11 +435,3 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             collected_frames,
             first_frame
         )
-
-def _find_downstream_time_warp_node(start_node):
-    # HACK: no idea why calling `dependentNodes` the first time
-    # seems to always return nothing.
-    nuke.dependentNodes(nuke.INPUTS, [start_node])
-    for node in nuke.dependentNodes(nuke.INPUTS, [start_node]):
-        if node.Class() == "TimeWarp":
-            return node

--- a/client/ayon_nuke/plugins/publish/collect_writes.py
+++ b/client/ayon_nuke/plugins/publish/collect_writes.py
@@ -190,7 +190,6 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         time_warp_node = _find_downstream_time_warp_node(
             instance.data["transientData"]["node"]
         )
-
         if time_warp_node:
             time_warp_dict = {
                 "Class": time_warp_node.Class(),


### PR DESCRIPTION
This PR fixes #337 

## Changelog Description

Fixed an issue where publishing complex Nuke scenes could freeze or crash during Collect Writes. Searching for downstream TimeWarp nodes no longer forces evaluation of the node graph, including in scenes that contain no TimeWarp nodes.

## Additional review information

Collect Writes searches downstream dependencies to determine whether TimeWarp metadata needs to be included in the published version data.

The previous implementation called `nuke.dependentNodes()` twice because the first call could return no results. These calls could force Nuke to evaluate the node graph while searching for a TimeWarp. In sufficiently complex scenes, this evaluation could cause Nuke to freeze and eventually crash—even when the composition contained no TimeWarp nodes.

The lookup now calls `Node.dependent()` from the publish instance node with `forceEvaluate=False`. This allows Collect Writes to inspect the available dependencies without triggering graph evaluation. If a TimeWarp is found, its lookup values continue to be collected as before; if none is found, publishing proceeds normally.

The obsolete `_find_downstream_time_warp_node()` helper and its repeated dependency queries were removed.

## Testing notes:

1. Launch Nuke.
2. Open a complex scene containing an AYON render, prerender, or image publish instance, but no TimeWarp nodes.
3. Publish the instance.
4. Confirm that Collect Writes completes without Nuke freezing or crashing.
5. Confirm that the publish finishes successfully.
6. Optionally repeat the test several times because the original issue occurred intermittently.
7. As a regression test, publish a scene with a downstream TimeWarp and confirm that the publish succeeds and its retime information is retained.

