### PR TITLE
fix: Saved workfile from ExporterReviewMov when run from Nuke terminal mode

### DIFF
--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1440,7 +1440,11 @@ class ExporterReviewMov(ExporterReview):
 
         # ---------- render or save to nk
         if self.publish_on_farm:
-            nuke.scriptSave()
+            # Force the save: a bare scriptSave() is modified-flag dependent
+            # and can no-op under `nuke -t`, leaving the bake .nk without its
+            # Write node. Same path, so save_file() still copies, not renames.
+            nuke.scriptSaveAs(
+                self.instance.context.data["currentFile"], overwrite=1)
             path_nk = self.save_file()
             self.data.update({
                 "bakeScriptPath": path_nk,
@@ -1466,7 +1470,10 @@ class ExporterReviewMov(ExporterReview):
         self.log.debug(f"Representation...   `{self.data}`")
 
         self.clean_nodes(product_name)
-        nuke.scriptSave()
+        # Forced as above, so the removed bake Write node does not persist
+        # in the artist's workfile.
+        nuke.scriptSaveAs(
+            self.instance.context.data["currentFile"], overwrite=1)
 
         return self.data
 

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1440,9 +1440,9 @@ class ExporterReviewMov(ExporterReview):
 
         # ---------- render or save to nk
         if self.publish_on_farm:
-            # Force the save: a bare scriptSave() is modified-flag dependent
-            # and can no-op under `nuke -t`, leaving the bake .nk without its
-            # Write node. Same path, so save_file() still copies, not renames.
+            # Save in place then copy as a separate workfile so the baked content
+            # get saved without touching Nuke current root instance.
+            # Cannot use nuke.scriptSave() as it has no effect in terminal mode.
             nuke.scriptSaveAs(
                 self.instance.context.data["currentFile"], overwrite=1)
             path_nk = self.save_file()
@@ -1470,8 +1470,7 @@ class ExporterReviewMov(ExporterReview):
         self.log.debug(f"Representation...   `{self.data}`")
 
         self.clean_nodes(product_name)
-        # Forced as above, so the removed bake Write node does not persist
-        # in the artist's workfile.
+        # Commit to cleaned workfile + session.
         nuke.scriptSaveAs(
             self.instance.context.data["currentFile"], overwrite=1)
 

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1440,9 +1440,9 @@ class ExporterReviewMov(ExporterReview):
 
         # ---------- render or save to nk
         if self.publish_on_farm:
-            # Save in place then copy as a separate workfile so the baked content
-            # get saved without touching Nuke current root instance.
-            # Cannot use nuke.scriptSave() as it has no effect in terminal mode.
+            # Save in place then copy as a separate workfile so the baked
+            # content get saved without touching Nuke current root instance.
+            # Cannot use nuke.scriptSave(), it has no effect in terminal mode.
             nuke.scriptSaveAs(
                 self.instance.context.data["currentFile"], overwrite=1)
             path_nk = self.save_file()


### PR DESCRIPTION
## Changelog Description

Fixes farm review baking crashing under headless publishing with `RuntimeError: Nothing is named "Write1"`. The temporary bake Write node was not being written to the on-disk workfile that the bake `.nk` is copied from, because the bare `nuke.scriptSave()` calls in `ExporterReviewMov.generate_mov()` are a no-op when the scene's modified flag is `False`, which is the case in a headless (`nuke -t`) publish. Both saves now use `nuke.scriptSaveAs(currentFile, overwrite=1)`, which writes unconditionally, so the bake script reliably contains its Write node and the workfile is left clean afterwards. No behavioural change for interactive (GUI) or local publishing.

## Additional review information

**Root cause.** In `ExporterReviewMov.generate_mov()` (`client/ayon_nuke/api/plugin.py`), the farm branch builds a temporary bake graph (Read, colour, Write), then persists it by:

1. `nuke.scriptSave()` to flush the in-memory bake Write node to the current workfile on disk, then
2. `save_file()` (`shutil.copyfile(context["currentFile"], <bake>.nk)`) to copy that workfile to the bake path.

`save_file()` copies the on-disk workfile rather than serialising the live graph. This is deliberate, so the live session is not renamed and `onScriptSave` callbacks are not fired. It therefore depends on step 1 having actually written the Write node to disk.

But `nuke.scriptSave()` is, by design, a no-op whenever `root.modified()` is `False`. In a headless publish the workfile is saved (clearing the modified flag) and the bake graph is then built purely via the Python API (`nuke.createNode` / `connectInput`), which does not set the flag back to `True`. So `scriptSave()` silently does nothing, the copied bake `.nk` lacks the Write node, and the Deadline render job, told to render `bakeWriteNodeName` (e.g. `Write1`), crashes on load. Interactively the flag is effectively always `True` by publish time (ongoing GUI edits), which is why this was never seen in GUI publishes.

The same no-op affects the **second** `nuke.scriptSave()` at the end of `generate_mov()` (after `clean_nodes()`), which restores the workfile once the temporary bake nodes are removed. Left unfixed, the transient bake Write node would remain persisted in the published workfile.

**Change.** Both bare `nuke.scriptSave()` calls become a forced save to the same path:

`overwrite=1` forces the write regardless of the modified flag. Saving to the **same** path means no `root.name()` / `project_directory` rename and no change to existing `onScriptSave` / `IncrementScriptVersion` behaviour. `save_file()` itself is unchanged.

**Why not `scriptSaveAs(bakePath)` directly?** That would rename the live session to the bake path mid-publish and fire the save callbacks, the exact behaviour the copy-based `save_file()` exists to avoid.

**Scope.** Farm review-bake path only. GUI/interactive publishes are unaffected (they already write the same content, since the flag is already `True`). The local `render()` branch does not use the saved `.nk`, so the second forced save is a no-op there (the workfile is already clean).

## Testing notes:

1. **Underlying no-op (AYON-free), `nuke -t`:** run the snippet below. Before the fix, `scriptSave -> bake has Write1` prints `False`; the forced save prints `True`. This also confirms `modified()` stays `False` after `createNode` in terminal mode.
   ```python
   import nuke, os, shutil, tempfile
   wf   = os.path.join(tempfile.gettempdir(), "wf.nk")
   bake = os.path.join(tempfile.gettempdir(), "bake.nk")
   nuke.scriptClear()
   nuke.createNode("Constant").setName("Comp")
   nuke.scriptSaveAs(wf, overwrite=1)
   nuke.root().setModified(False)
   nuke.createNode("Write").setName("Write1")
   print("modified:", nuke.root().modified())                                    # False
   nuke.scriptSave(); shutil.copyfile(wf, bake)
   print("scriptSave   -> bake has Write1:", "name Write1" in open(bake).read()) # False (bug)
   nuke.scriptSaveAs(wf, overwrite=1); shutil.copyfile(wf, bake)
   print("scriptSaveAs -> bake has Write1:", "name Write1" in open(bake).read()) # True (fixed)
   ```
2. **Headless farm publish (end-to-end):** publish a Nuke review with `render_target = farm` from a headless session (`nuke -t`).
3. Confirm the generated `<review>.nk` under `.../renders/nuke/<review>/` now **contains** the `bakeWriteNodeName` Write node (e.g. grep for `name Write1`).
4. Confirm the Deadline bake job loads that script and **renders to completion**, with no `RuntimeError: Nothing is named "Write1"`.
5. **Workfile stays clean:** confirm the published workfile version(s) do **not** contain the bake Write node (`grep -L "name Write1" <workfile>.nk`).
6. **GUI regression:** publish the same review interactively (GUI) and confirm the review still generates correctly (no change).

#340 