### PR TITLE
[YN-0771]: Adds output type selection for intermediate presets

### DIFF
--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1183,7 +1183,7 @@ class ExporterReviewMov(ExporterReview):
                  klass,
                  instance,
                  name=None,
-                 ext=None,
+                 settings=None,
                  multiple_presets=True
                  ):
         # initialize parent class
@@ -1197,9 +1197,21 @@ class ExporterReviewMov(ExporterReview):
         self.write_colorspace = instance.data["colorspace"]
         self.color_channels = instance.data["color_channels"]
         self.formatting_data = instance.data["anatomyData"]
+        self.settings = settings or {}
 
         self.name = name or "baked"
-        self.ext = ext or "mov"
+        if settings["output_type"] == "extension":
+            self.ext = settings["extension"] or "mov"
+
+        elif settings["output_type"] == "custom_write_knobs":
+            for knob in settings["custom_write_knobs"]:
+                if knob["name"] == "file_type":
+                    self.ext = knob["value"]
+                    break
+            else:
+                self.ext = "mov"
+        else:
+            self.ext = "mov"
 
         # set frame start / end and file name to self
         self.get_file_info()
@@ -1409,28 +1421,43 @@ class ExporterReviewMov(ExporterReview):
         self.log.debug(f"Path: {self.path}")
 
         write_node["file"].setValue(str(self.path))
-        write_node["file_type"].setValue(str(self.ext))
-        write_node["channels"].setValue(str(self.color_channels))
 
-        # Knobs `meta_codec` and `mov64_codec` are not available on centos.
-        # TODO shouldn't this come from settings on outputs?
-        try:
-            write_node["meta_codec"].setValue("ap4h")
-        except Exception:
-            self.log.info("`meta_codec` knob was not found")
+        if self.settings["output_type"] == "extension":
+            write_node["file_type"].setValue(str(self.ext))
+            write_node["channels"].setValue(str(self.color_channels))
 
-        try:
-            write_node["mov64_codec"].setValue("ap4h")
-            write_node["mov64_fps"].setValue(float(fps))
-        except Exception:
-            self.log.info("`mov64_codec` knob was not found")
+            # Knobs `meta_codec` and `mov64_codec` are not available on centos.
+            # TODO shouldn't this come from settings on outputs?
+            try:
+                write_node["meta_codec"].setValue("ap4h")
+            except Exception:
+                self.log.info("`meta_codec` knob was not found")
 
-        try:
-            write_node["mov64_write_timecode"].setValue(1)
-        except Exception:
-            self.log.info("`mov64_write_timecode` knob was not found")
+            try:
+                write_node["mov64_codec"].setValue("ap4h")
+                write_node["mov64_fps"].setValue(float(fps))
+            except Exception:
+                self.log.info("`mov64_codec` knob was not found")
 
-        write_node["raw"].setValue(1)
+            try:
+                write_node["mov64_write_timecode"].setValue(1)
+            except Exception:
+                self.log.info("`mov64_write_timecode` knob was not found")
+
+            write_node["raw"].setValue(1)
+
+        elif self.settings["output_type"] == "custom_write_knobs":
+            write_node["file_type"].setValue(str(self.ext))
+            write_node["channels"].setValue(str(self.color_channels))
+            write_node["raw"].setValue(1)
+
+            for knob in self.settings["custom_write_knobs"]:
+                try:
+                    write_node[knob["name"]].setValue(knob["value"])
+                except Exception:
+                    self.log.info(
+                        f"`{knob['name']}` knob was not found on Write node"
+                    )
 
         # connect
         write_node.setInput(0, self.previous_node)

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1205,14 +1205,23 @@ class ExporterReviewMov(ExporterReview):
 
         output_type = self._get_output_type()
         if output_type == "custom_write_knobs":
+            file_type = None
             for knob in self.settings.get("custom_write_knobs") or []:
-                if knob["name"] == "file_type":
-                    self.ext = knob["text"] or "mov"
+                if knob.get("name") == "file_type":
+                    file_type = knob.get("text")
                     break
-            else:
-                self.ext = "mov"
+
+            if not file_type:
+                raise ValueError(
+                    "Invalid custom_write_knobs settings: "
+                    "expected a non-empty 'file_type' "
+                    "knob text value when output_type is "
+                    "'custom_write_knobs'."
+                )
+
+            self.ext = file_type
         else:
-            self.ext = self.settings.get("extension") or "mov"
+            self.ext = self.settings.get("extension", "mov")
 
         # set frame start / end and file name to self
         self.get_file_info()
@@ -1451,7 +1460,10 @@ class ExporterReviewMov(ExporterReview):
             if "mov64_fps" in write_node.knobs():
                 write_node["mov64_fps"].setValue(float(fps))
         else:
-            self._configure_write_node(write_node, fps)
+            raise ValueError(
+                f"Invalid output type: {output_type}. "
+                "Expected 'extension' or 'custom_write_knobs'."
+            )
 
         # connect
         write_node.setInput(0, self.previous_node)

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1185,7 +1185,7 @@ class ExporterReviewMov(ExporterReview):
                  klass,
                  instance,
                  name=None,
-                 settings=None,
+                 write_knobs=None,
                  multiple_presets=True
                  ):
         # initialize parent class
@@ -1199,30 +1199,9 @@ class ExporterReviewMov(ExporterReview):
         self.write_colorspace = instance.data["colorspace"]
         self.color_channels = instance.data["color_channels"]
         self.formatting_data = instance.data["anatomyData"]
-        self.settings = settings or {}
+        self.custom_write_knobs = write_knobs["custom"]
         self.name = name or "baked"
-
-        custom_write_knobs = self.settings.get("custom_write_knobs", [])
-        if custom_write_knobs:
-            file_type = None
-            for knob in custom_write_knobs:
-                if knob.get("name") == "file_type":
-                    file_type = knob.get("text")
-                    break
-
-            if not file_type:
-                raise ValueError(
-                    "Invalid custom_write_knobs settings: "
-                    "expected a non-empty 'file_type' "
-                    "knob text value when output_type is "
-                    "'custom_write_knobs'."
-                )
-
-            self.ext = file_type
-        else:
-            # backwards compatibility for old settings to
-            # get extension
-            self.ext = self.settings.get("extension", "mov")
+        self.ext = write_knobs["file_type"]
 
         # set frame start / end and file name to self
         self.get_file_info()
@@ -1431,10 +1410,8 @@ class ExporterReviewMov(ExporterReview):
         write_node = nuke.createNode("Write")
         self.log.debug(f"Path: {self.path}")
         write_node["file"].setValue(str(self.path))
-
-        custom_write_knobs = self.settings.get("custom_write_knobs") or []
-        if custom_write_knobs:
-            for knob in custom_write_knobs:
+        if self.custom_write_knobs:
+            for knob in self.custom_write_knobs:
                 if knob["name"] in {
                     "file", "file_type",
                     "channels", "raw", "mov64_fps"
@@ -1446,11 +1423,7 @@ class ExporterReviewMov(ExporterReview):
                 )
                 write_node[knob["name"]].setValue(value)
 
-            self._set_write_node_defaults(write_node, fps)
-        else:
-            # backward compatibility for old settings
-            # with only extension defined
-            self._set_write_node_defaults(write_node, fps)
+        self._set_write_node_defaults(write_node, fps)
 
         # connect
         write_node.setInput(0, self.previous_node)

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1479,6 +1479,7 @@ class ExporterReviewMov(ExporterReview):
         Args:
             write_node: The write node to configure.
             custom_knobs: List of custom knob configurations.
+            log: Logger for logging warnings and information.
         """
         if not custom_knobs:
             return

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1206,7 +1206,7 @@ class ExporterReviewMov(ExporterReview):
         elif settings["output_type"] == "custom_write_knobs":
             for knob in settings["custom_write_knobs"]:
                 if knob["name"] == "file_type":
-                    self.ext = knob["value"]
+                    self.ext = knob["text"] or "mov"
                     break
             else:
                 self.ext = "mov"
@@ -1450,10 +1450,24 @@ class ExporterReviewMov(ExporterReview):
             write_node["file_type"].setValue(str(self.ext))
             write_node["channels"].setValue(str(self.color_channels))
             write_node["raw"].setValue(1)
+            if "mov64_fps" in write_node.knobs():
+                write_node["mov64_fps"].setValue(float(fps))
 
             for knob in self.settings["custom_write_knobs"]:
                 try:
-                    write_node[knob["name"]].setValue(knob["value"])
+                    if knob["type"] == "text":
+                        write_node[knob["name"]].setValue(str(knob["text"]))
+                    elif knob["type"] == "number":
+                        write_node[knob["name"]].setValue(int(knob["number"]))
+                    elif knob["type"] == "decimal_number":
+                        write_node[knob["name"]].setValue(float(knob["decimal_number"]))
+                    elif knob["type"] == "boolean":
+                        write_node[knob["name"]].setValue(bool(knob["boolean"]))
+                    else:
+                        self.log.warning(
+                            f"Knob type `{knob['type']}` is not supported"
+                        )
+
                 except Exception:
                     self.log.info(
                         f"`{knob['name']}` knob was not found on Write node"

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1203,10 +1203,10 @@ class ExporterReviewMov(ExporterReview):
         self.settings = settings or {}
         self.name = name or "baked"
 
-        output_type = self._get_output_type()
-        if output_type == "custom_write_knobs":
+        custom_write_knobs = self.settings.get("custom_write_knobs", [])
+        if custom_write_knobs:
             file_type = None
-            for knob in self.settings.get("custom_write_knobs") or []:
+            for knob in custom_write_knobs:
                 if knob.get("name") == "file_type":
                     file_type = knob.get("text")
                     break
@@ -1221,6 +1221,8 @@ class ExporterReviewMov(ExporterReview):
 
             self.ext = file_type
         else:
+            # backwards compatibility for old settings to
+            # get extension
             self.ext = self.settings.get("extension", "mov")
 
         # set frame start / end and file name to self
@@ -1244,14 +1246,6 @@ class ExporterReviewMov(ExporterReview):
                 self.fhead, self.name, after_head, self.ext)
         self.path = os.path.join(
             self.staging_dir, self.file).replace("\\", "/")
-
-    def _get_output_type(self) -> Literal["extension", "custom_write_knobs"]:
-        """Get the output type from settings.
-
-        Returns:
-            Literal["extension", "custom_write_knobs"]: output type
-        """
-        return self.settings.get("output_type", "extension")
 
     def clean_nodes(self, node_name):
         for node in self._temp_nodes[node_name]:
@@ -1439,12 +1433,9 @@ class ExporterReviewMov(ExporterReview):
         self.log.debug(f"Path: {self.path}")
         write_node["file"].setValue(str(self.path))
 
-        output_type = self._get_output_type()
-        if output_type == "extension":
-            self._set_write_node_defaults(write_node, fps)
-
-        elif output_type == "custom_write_knobs":
-            for knob in self.settings.get("custom_write_knobs") or []:
+        custom_write_knobs = self.settings.get("custom_write_knobs") or []
+        if custom_write_knobs:
+            for knob in custom_write_knobs:
                 if knob["name"] in {
                     "file", "file_type",
                     "channels", "raw", "mov64_fps"
@@ -1458,10 +1449,9 @@ class ExporterReviewMov(ExporterReview):
 
             self._set_write_node_defaults(write_node, fps)
         else:
-            raise ValueError(
-                f"Invalid output type: {output_type}. "
-                "Expected 'extension' or 'custom_write_knobs'."
-            )
+            # backward compatibility for old settings
+            # with only extension defined
+            self._set_write_node_defaults(write_node, fps)
 
         # connect
         write_node.setInput(0, self.previous_node)

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1198,20 +1198,18 @@ class ExporterReviewMov(ExporterReview):
         self.color_channels = instance.data["color_channels"]
         self.formatting_data = instance.data["anatomyData"]
         self.settings = settings or {}
-
         self.name = name or "baked"
-        if settings["output_type"] == "extension":
-            self.ext = settings["extension"] or "mov"
 
-        elif settings["output_type"] == "custom_write_knobs":
-            for knob in settings["custom_write_knobs"]:
+        output_type = self.settings.get("output_type", "extension")
+        if output_type == "custom_write_knobs":
+            for knob in self.settings.get("custom_write_knobs") or []:
                 if knob["name"] == "file_type":
                     self.ext = knob["text"] or "mov"
                     break
             else:
                 self.ext = "mov"
         else:
-            self.ext = "mov"
+            self.ext = self.settings.get("extension") or "mov"
 
         # set frame start / end and file name to self
         self.get_file_info()
@@ -1419,10 +1417,10 @@ class ExporterReviewMov(ExporterReview):
         # Write node
         write_node = nuke.createNode("Write")
         self.log.debug(f"Path: {self.path}")
-
         write_node["file"].setValue(str(self.path))
 
-        if self.settings["output_type"] == "extension":
+        output_type = self.settings.get("output_type", "extension")
+        if output_type == "extension":
             write_node["file_type"].setValue(str(self.ext))
             write_node["channels"].setValue(str(self.color_channels))
 
@@ -1446,14 +1444,16 @@ class ExporterReviewMov(ExporterReview):
 
             write_node["raw"].setValue(1)
 
-        elif self.settings["output_type"] == "custom_write_knobs":
+        elif output_type == "custom_write_knobs":
+            # force setting file type and channels
+            # to avoid export issues
             write_node["file_type"].setValue(str(self.ext))
             write_node["channels"].setValue(str(self.color_channels))
             write_node["raw"].setValue(1)
             if "mov64_fps" in write_node.knobs():
                 write_node["mov64_fps"].setValue(float(fps))
 
-            for knob in self.settings["custom_write_knobs"]:
+            for knob in self.settings.get("custom_write_knobs") or []:
                 try:
                     if knob["type"] == "text":
                         write_node[knob["name"]].setValue(str(knob["text"]))
@@ -1472,6 +1472,29 @@ class ExporterReviewMov(ExporterReview):
                     self.log.info(
                         f"`{knob['name']}` knob was not found on Write node"
                     )
+
+        else:
+            write_node["file_type"].setValue(str(self.ext))
+            write_node["channels"].setValue(str(self.color_channels))
+            write_node["raw"].setValue(1)
+
+            # Knobs `meta_codec` and `mov64_codec` are not available on centos.
+            # TODO shouldn't this come from settings on outputs?
+            try:
+                write_node["meta_codec"].setValue("ap4h")
+            except Exception:
+                self.log.info("`meta_codec` knob was not found")
+
+            try:
+                write_node["mov64_codec"].setValue("ap4h")
+                write_node["mov64_fps"].setValue(float(fps))
+            except Exception:
+                self.log.info("`mov64_codec` knob was not found")
+
+            try:
+                write_node["mov64_write_timecode"].setValue(1)
+            except Exception:
+                self.log.info("`mov64_write_timecode` knob was not found")
 
         # connect
         write_node.setInput(0, self.previous_node)

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1485,19 +1485,16 @@ class ExporterReviewMov(ExporterReview):
             return
 
         for knob in custom_knobs:
-            if knob["name"] in {
-                "file", "file_type",
-                "channels", "raw", "mov64_fps"
-            }:
-                log.warning(
-                    f"Skipping to set custom knob '{knob['name']}' "
-                    "as it is already set in defaults."
-                )
-                continue
             to_type = knob["type"]
             value = convert_knob_value_to_correct_type(
                 to_type, knob[to_type]
             )
+            if knob["name"] not in write_node.knobs():
+                log.warning(
+                    f"Knob '{knob['name']}' does not exist on the write node. "
+                    "Skipping setting this knob."
+                )
+                continue
             write_node[knob["name"]].setValue(value)
 
 

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1,4 +1,3 @@
-from typing import Literal
 
 import nuke
 import re

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import nuke
 import re
 import os
@@ -1201,7 +1203,7 @@ class ExporterReviewMov(ExporterReview):
         self.settings = settings or {}
         self.name = name or "baked"
 
-        output_type = self.settings.get("output_type", "extension")
+        output_type = self._get_output_type()
         if output_type == "custom_write_knobs":
             for knob in self.settings.get("custom_write_knobs") or []:
                 if knob["name"] == "file_type":
@@ -1233,6 +1235,14 @@ class ExporterReviewMov(ExporterReview):
                 self.fhead, self.name, after_head, self.ext)
         self.path = os.path.join(
             self.staging_dir, self.file).replace("\\", "/")
+
+    def _get_output_type(self) -> Literal["extension", "custom_write_knobs"]:
+        """Get the output type from settings.
+
+        Returns:
+            Literal["extension", "custom_write_knobs"]: output type
+        """
+        return self.settings.get("output_type", "extension")
 
     def clean_nodes(self, node_name):
         for node in self._temp_nodes[node_name]:
@@ -1420,7 +1430,7 @@ class ExporterReviewMov(ExporterReview):
         self.log.debug(f"Path: {self.path}")
         write_node["file"].setValue(str(self.path))
 
-        output_type = self.settings.get("output_type", "extension")
+        output_type = self._get_output_type()
         if output_type == "extension":
             self._configure_write_node(write_node, fps)
 

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -45,6 +45,7 @@ from .lib import (
     get_work_default_directory,
     link_knobs,
     get_version_from_path,
+    convert_knob_value_to_correct_type,
 )
 from .pipeline import (
     list_instances,
@@ -1421,80 +1422,24 @@ class ExporterReviewMov(ExporterReview):
 
         output_type = self.settings.get("output_type", "extension")
         if output_type == "extension":
-            write_node["file_type"].setValue(str(self.ext))
-            write_node["channels"].setValue(str(self.color_channels))
-
-            # Knobs `meta_codec` and `mov64_codec` are not available on centos.
-            # TODO shouldn't this come from settings on outputs?
-            try:
-                write_node["meta_codec"].setValue("ap4h")
-            except Exception:
-                self.log.info("`meta_codec` knob was not found")
-
-            try:
-                write_node["mov64_codec"].setValue("ap4h")
-                write_node["mov64_fps"].setValue(float(fps))
-            except Exception:
-                self.log.info("`mov64_codec` knob was not found")
-
-            try:
-                write_node["mov64_write_timecode"].setValue(1)
-            except Exception:
-                self.log.info("`mov64_write_timecode` knob was not found")
-
-            write_node["raw"].setValue(1)
+            self._configure_write_node(write_node, fps)
 
         elif output_type == "custom_write_knobs":
-            # force setting file type and channels
-            # to avoid export issues
-            write_node["file_type"].setValue(str(self.ext))
-            write_node["channels"].setValue(str(self.color_channels))
-            write_node["raw"].setValue(1)
+            for knob in self.settings.get("custom_write_knobs") or []:
+                if knob["name"] in {
+                    "file", "file_type",
+                    "channels", "raw", "mov64_fps"
+                }:
+                    continue
+
+                value = convert_knob_value_to_correct_type(write_node, knob)
+                write_node[knob["name"]].setValue(value)
+
+            self._set_write_node_defaults(write_node)
             if "mov64_fps" in write_node.knobs():
                 write_node["mov64_fps"].setValue(float(fps))
-
-            for knob in self.settings.get("custom_write_knobs") or []:
-                try:
-                    if knob["type"] == "text":
-                        write_node[knob["name"]].setValue(str(knob["text"]))
-                    elif knob["type"] == "number":
-                        write_node[knob["name"]].setValue(int(knob["number"]))
-                    elif knob["type"] == "decimal_number":
-                        write_node[knob["name"]].setValue(float(knob["decimal_number"]))
-                    elif knob["type"] == "boolean":
-                        write_node[knob["name"]].setValue(bool(knob["boolean"]))
-                    else:
-                        self.log.warning(
-                            f"Knob type `{knob['type']}` is not supported"
-                        )
-
-                except Exception:
-                    self.log.info(
-                        f"`{knob['name']}` knob was not found on Write node"
-                    )
-
         else:
-            write_node["file_type"].setValue(str(self.ext))
-            write_node["channels"].setValue(str(self.color_channels))
-            write_node["raw"].setValue(1)
-
-            # Knobs `meta_codec` and `mov64_codec` are not available on centos.
-            # TODO shouldn't this come from settings on outputs?
-            try:
-                write_node["meta_codec"].setValue("ap4h")
-            except Exception:
-                self.log.info("`meta_codec` knob was not found")
-
-            try:
-                write_node["mov64_codec"].setValue("ap4h")
-                write_node["mov64_fps"].setValue(float(fps))
-            except Exception:
-                self.log.info("`mov64_codec` knob was not found")
-
-            try:
-                write_node["mov64_write_timecode"].setValue(1)
-            except Exception:
-                self.log.info("`mov64_write_timecode` knob was not found")
+            self._configure_write_node(write_node, fps)
 
         # connect
         write_node.setInput(0, self.previous_node)
@@ -1542,6 +1487,43 @@ class ExporterReviewMov(ExporterReview):
     def _connect_to_above_nodes(self, node, product_name, message):
         node.setInput(0, self.previous_node)
         self._shift_to_previous_node_and_temp(product_name, node, message)
+
+    def _configure_write_node(self, write_node, fps) -> None:
+        """Set write node configuration.
+
+        Args:
+            write_node: The write node to configure.
+            fps: Frames per second for the write node.
+        """
+        self._set_write_node_defaults(write_node)
+
+        # Knobs `meta_codec` and `mov64_codec` are not available on centos.
+        # TODO shouldn't this come from settings on outputs?
+        try:
+            write_node["meta_codec"].setValue("ap4h")
+        except Exception:
+            self.log.info("`meta_codec` knob was not found")
+
+        try:
+            write_node["mov64_codec"].setValue("ap4h")
+            write_node["mov64_fps"].setValue(float(fps))
+        except Exception:
+            self.log.info("`mov64_codec` knob was not found")
+
+        try:
+            write_node["mov64_write_timecode"].setValue(1)
+        except Exception:
+            self.log.info("`mov64_write_timecode` knob was not found")
+
+    def _set_write_node_defaults(self, write_node) -> None:
+        """Set default write node configuration.
+
+        Args:
+            write_node: The write node to configure.
+        """
+        write_node["file_type"].setValue(str(self.ext))
+        write_node["channels"].setValue(str(self.color_channels))
+        write_node["raw"].setValue(1)
 
 
 def convert_to_valid_instaces():

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1441,7 +1441,7 @@ class ExporterReviewMov(ExporterReview):
 
         output_type = self._get_output_type()
         if output_type == "extension":
-            self._configure_write_node(write_node, fps)
+            self._set_write_node_defaults(write_node, fps)
 
         elif output_type == "custom_write_knobs":
             for knob in self.settings.get("custom_write_knobs") or []:
@@ -1456,9 +1456,7 @@ class ExporterReviewMov(ExporterReview):
                 )
                 write_node[knob["name"]].setValue(value)
 
-            self._set_write_node_defaults(write_node)
-            if "mov64_fps" in write_node.knobs():
-                write_node["mov64_fps"].setValue(float(fps))
+            self._set_write_node_defaults(write_node, fps)
         else:
             raise ValueError(
                 f"Invalid output type: {output_type}. "
@@ -1512,42 +1510,18 @@ class ExporterReviewMov(ExporterReview):
         node.setInput(0, self.previous_node)
         self._shift_to_previous_node_and_temp(product_name, node, message)
 
-    def _configure_write_node(self, write_node, fps) -> None:
-        """Set write node configuration.
+    def _set_write_node_defaults(self, write_node, fps) -> None:
+        """Set default write node configuration.
 
         Args:
             write_node: The write node to configure.
             fps: Frames per second for the write node.
         """
-        self._set_write_node_defaults(write_node)
-
-        # Knobs `meta_codec` and `mov64_codec` are not available on centos.
-        # TODO shouldn't this come from settings on outputs?
-        try:
-            write_node["meta_codec"].setValue("ap4h")
-        except Exception:
-            self.log.info("`meta_codec` knob was not found")
-
-        try:
-            write_node["mov64_codec"].setValue("ap4h")
-            write_node["mov64_fps"].setValue(float(fps))
-        except Exception:
-            self.log.info("`mov64_codec` knob was not found")
-
-        try:
-            write_node["mov64_write_timecode"].setValue(1)
-        except Exception:
-            self.log.info("`mov64_write_timecode` knob was not found")
-
-    def _set_write_node_defaults(self, write_node) -> None:
-        """Set default write node configuration.
-
-        Args:
-            write_node: The write node to configure.
-        """
         write_node["file_type"].setValue(str(self.ext))
         write_node["channels"].setValue(str(self.color_channels))
         write_node["raw"].setValue(1)
+        if "mov64_fps" in write_node.knobs():
+            write_node["mov64_fps"].setValue(float(fps))
 
 
 def convert_to_valid_instaces():

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1441,8 +1441,10 @@ class ExporterReviewMov(ExporterReview):
                     "channels", "raw", "mov64_fps"
                 }:
                     continue
-
-                value = convert_knob_value_to_correct_type(write_node, knob)
+                to_type = knob["type"]
+                value = convert_knob_value_to_correct_type(
+                    to_type, knob[to_type]
+                )
                 write_node[knob["name"]].setValue(value)
 
             self._set_write_node_defaults(write_node)

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1495,13 +1495,14 @@ class ExporterReviewMov(ExporterReview):
             value = convert_knob_value_to_correct_type(
                 to_type, knob[to_type]
             )
-            if knob["name"] not in write_node.knobs():
+            name = knob["name"]
+            if name not in write_node.knobs():
                 log.warning(
-                    f"Knob '{knob['name']}' does not exist on the write node. "
+                    f"Knob '{name}' does not exist on the write node. "
                     "Skipping setting this knob."
                 )
                 continue
-            write_node[knob["name"]].setValue(value)
+            write_node[name].setValue(value)
 
 
 def convert_to_valid_instaces():

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1410,20 +1410,8 @@ class ExporterReviewMov(ExporterReview):
         write_node = nuke.createNode("Write")
         self.log.debug(f"Path: {self.path}")
         write_node["file"].setValue(str(self.path))
-        if self.custom_write_knobs:
-            for knob in self.custom_write_knobs:
-                if knob["name"] in {
-                    "file", "file_type",
-                    "channels", "raw", "mov64_fps"
-                }:
-                    continue
-                to_type = knob["type"]
-                value = convert_knob_value_to_correct_type(
-                    to_type, knob[to_type]
-                )
-                write_node[knob["name"]].setValue(value)
-
         self._set_write_node_defaults(write_node, fps)
+        self._set_custom_knobs(write_node, self.custom_write_knobs, self.log)
 
         # connect
         write_node.setInput(0, self.previous_node)
@@ -1484,6 +1472,32 @@ class ExporterReviewMov(ExporterReview):
         write_node["raw"].setValue(1)
         if "mov64_fps" in write_node.knobs():
             write_node["mov64_fps"].setValue(float(fps))
+
+    def _set_custom_knobs(self, write_node, custom_knobs, log) -> None:
+        """Set custom knobs on the write node.
+
+        Args:
+            write_node: The write node to configure.
+            custom_knobs: List of custom knob configurations.
+        """
+        if not custom_knobs:
+            return
+
+        for knob in custom_knobs:
+            if knob["name"] in {
+                "file", "file_type",
+                "channels", "raw", "mov64_fps"
+            }:
+                log.warning(
+                    f"Skipping to set custom knob '{knob['name']}' "
+                    "as it is already set in defaults."
+                )
+                continue
+            to_type = knob["type"]
+            value = convert_knob_value_to_correct_type(
+                to_type, knob[to_type]
+            )
+            write_node[knob["name"]].setValue(value)
 
 
 def convert_to_valid_instaces():

--- a/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
+++ b/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
@@ -115,8 +115,8 @@ class ExtractReviewIntermediates(publish.Extractor):
                     instance,
                     name=o_name,
                     settings=o_data,
-                    multiple_presets=multiple_presets,
-                    multiple_presets)
+                    multiple_presets=multiple_presets
+                )
 
                 delete = not o_data.get("publish", False)
 

--- a/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
+++ b/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
@@ -111,7 +111,7 @@ class ExtractReviewIntermediates(publish.Extractor):
 
                 # create exporter instance
                 exporter = plugin.ExporterReviewMov(
-                    self, instance, o_name, o_data["extension"],
+                    self, instance, o_name, o_data,
                     multiple_presets)
 
                 delete = not o_data.get("publish", False)

--- a/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
+++ b/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
@@ -111,7 +111,11 @@ class ExtractReviewIntermediates(publish.Extractor):
 
                 # create exporter instance
                 exporter = plugin.ExporterReviewMov(
-                    self, instance, o_name, o_data,
+                    self,
+                    instance,
+                    name=o_name,
+                    settings=o_data,
+                    multiple_presets=multiple_presets,
                     multiple_presets)
 
                 delete = not o_data.get("publish", False)

--- a/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
+++ b/client/ayon_nuke/plugins/publish/extract_review_intermediates.py
@@ -114,7 +114,7 @@ class ExtractReviewIntermediates(publish.Extractor):
                     self,
                     instance,
                     name=o_name,
-                    settings=o_data,
+                    write_knobs=o_data["write_knobs"],
                     multiple_presets=multiple_presets
                 )
 

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -322,22 +322,18 @@ def _convert_review_intermediates_model_0_4_11(
         write_knobs["file_type"] = extension
 
         if write_knobs.get("custom") is None:
-            custom: list[KnobModel] = SettingsField(
-                title="Additional Knobs",
-                default=[
-                    KnobModel(
-                        type="text",
-                        name="mov64_codec",
-                        text="ap4h",
-                    ),
-                    KnobModel(
-                        type="boolean",
-                        name="mov64_write_timecode",
-                        boolean=True,
-                    )
-                ]
-            )
-            write_knobs["custom"] = custom
+            write_knobs["custom"] = [
+                {
+                    "type": "text",
+                    "name": "mov64_codec",
+                    "text": "ap4h",
+                },
+                {
+                    "type": "boolean",
+                    "name": "mov64_write_timecode",
+                    "boolean": True,
+                },
+            ]
 
 
 def convert_settings_overrides(

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -2,6 +2,8 @@ import re
 from typing import Any
 from copy import deepcopy
 from semver import VersionInfo
+from ayon_server.settings import SettingsField
+from .common import KnobModel
 
 
 def _get_viewer_config_from_string(input_string):
@@ -302,7 +304,7 @@ def _convert_review_intermediates_model_0_4_11(
         overrides: dict, version: VersionInfo) -> None:
     """Convert review intermediates extension model to include
     file_type extension."""
-    if (version.major, version.minor, version.patch) >= (0, 4, 11):
+    if (version.major, version.minor, version.patch) > (0, 4, 11):
         return
     extract_review_outputs = (
         overrides
@@ -320,18 +322,22 @@ def _convert_review_intermediates_model_0_4_11(
         write_knobs["file_type"] = extension
 
         if write_knobs.get("custom") is None:
-            write_knobs["custom"] = [
-                {
-                    "type": "text",
-                    "name": "mov64_codec",
-                    "text": "ap4h",
-                },
-                {
-                    "type": "boolean",
-                    "name": "mov64_write_timecode",
-                    "boolean": True,
-                },
-            ]
+            custom: list[KnobModel] = SettingsField(
+                title="Additional Knobs",
+                default=[
+                    KnobModel(
+                        type="text",
+                        name="mov64_codec",
+                        text="ap4h",
+                    ),
+                    KnobModel(
+                        type="boolean",
+                        name="mov64_write_timecode",
+                        boolean=True,
+                    )
+                ]
+            )
+            write_knobs["custom"] = custom
 
 
 def convert_settings_overrides(

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -315,7 +315,7 @@ def _convert_review_intermediates_model_0_4_11(overrides: dict) -> None:
         write_knobs = output.setdefault("write_knobs", {})
         write_knobs["file_type"] = extension
 
-        if "custom" not in write_knobs or write_knobs["custom"] is None:
+        if write_knobs.get("custom") is None:
             write_knobs["custom"] = [
                 {
                     "type": "text",

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any
 from copy import deepcopy
+from semver import VersionInfo
 
 
 def _get_viewer_config_from_string(input_string):
@@ -297,9 +298,12 @@ def _convert_collect_sync_workfile_version_model_0_4_5(overrides: dict) -> None:
     ] = sync_workfile_version_on_product_base_types
 
 
-def _convert_review_intermediates_model_0_4_11(overrides: dict) -> None:
+def _convert_review_intermediates_model_0_4_11(
+        overrides: dict, version: VersionInfo) -> None:
     """Convert review intermediates extension model to include
     file_type extension."""
+    if (version.major, version.minor, version.patch) >= (0, 4, 11):
+        return
     extract_review_outputs = (
         overrides
         .get("publish", {})
@@ -334,6 +338,7 @@ def convert_settings_overrides(
     source_version: str,
     overrides: dict[str, Any],
 ) -> dict[str, Any]:
+    version = VersionInfo.parse(source_version)
     _convert_gizmo_menu_0_3_1(overrides)
     _convert_imageio_configs_0_2_3(overrides)
     _convert_publish_plugins(overrides)
@@ -342,5 +347,5 @@ def convert_settings_overrides(
     _convert_baking_stream_filter_product_base_type_0_4_0(overrides)
     _convert_collect_instance_data_model_0_4_0(overrides)
     _convert_collect_sync_workfile_version_model_0_4_5(overrides)
-    _convert_review_intermediates_model_0_4_11(overrides)
+    _convert_review_intermediates_model_0_4_11(overrides, version)
     return overrides

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -297,6 +297,24 @@ def _convert_collect_sync_workfile_version_model_0_4_5(overrides: dict) -> None:
     ] = sync_workfile_version_on_product_base_types
 
 
+def _convert_review_intermediates_model_0_4_11(overrides: dict) -> None:
+    """Convert review intermediates extension model to include
+    file_type extension."""
+    extract_review_outputs = (
+        overrides
+        .get("publish", {})
+        .get("ExtractReviewIntermediates", {})
+        .get("outputs")
+    )
+    for output in extract_review_outputs:
+        extension = output.pop("extension", None)
+        if not extension:
+            # Nothing to convert
+            return
+        write_knobs = output.get("write_knobs")
+        write_knobs["file_type"] = extension
+
+
 def convert_settings_overrides(
     source_version: str,
     overrides: dict[str, Any],
@@ -309,4 +327,5 @@ def convert_settings_overrides(
     _convert_baking_stream_filter_product_base_type_0_4_0(overrides)
     _convert_collect_instance_data_model_0_4_0(overrides)
     _convert_collect_sync_workfile_version_model_0_4_5(overrides)
+    _convert_review_intermediates_model_0_4_11(overrides)
     return overrides

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -2,8 +2,6 @@ import re
 from typing import Any
 from copy import deepcopy
 from semver import VersionInfo
-from ayon_server.settings import SettingsField
-from .common import KnobModel
 
 
 def _get_viewer_config_from_string(input_string):

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -3,22 +3,6 @@ from typing import Any
 from copy import deepcopy
 
 
-def _get_custom_knobs_list() -> list[dict[str, Any]]:
-    """Return a list of custom knobs for review intermediate mov files."""
-    return [
-        {
-            "type": "text",
-            "name": "mov64_codec",
-            "text": "ap4h",
-        },
-        {
-            "type": "boolean",
-            "name": "mov64_write_timecode",
-            "boolean": True,
-        },
-    ]
-
-
 def _get_viewer_config_from_string(input_string):
     """Convert string to display and viewer string
 
@@ -330,14 +314,6 @@ def _convert_review_intermediates_model_0_4_11(overrides: dict) -> None:
 
         write_knobs = output.setdefault("write_knobs", {})
         write_knobs["file_type"] = extension
-        if extension != "mov":
-            continue
-
-        custom_knobs = write_knobs.get("custom")
-        if custom_knobs:
-            continue
-
-        write_knobs["custom"] = _get_custom_knobs_list()
 
 
 def convert_settings_overrides(

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -315,6 +315,20 @@ def _convert_review_intermediates_model_0_4_11(overrides: dict) -> None:
         write_knobs = output.setdefault("write_knobs", {})
         write_knobs["file_type"] = extension
 
+        if "custom" not in write_knobs or write_knobs["custom"] is None:
+            write_knobs["custom"] = [
+                {
+                    "type": "text",
+                    "name": "mov64_codec",
+                    "text": "ap4h",
+                },
+                {
+                    "type": "boolean",
+                    "name": "mov64_write_timecode",
+                    "boolean": True,
+                },
+            ]
+
 
 def convert_settings_overrides(
     source_version: str,

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -3,6 +3,22 @@ from typing import Any
 from copy import deepcopy
 
 
+def _get_custom_knobs_list() -> list[dict[str, Any]]:
+    """Return a list of custom knobs for review intermediate mov files."""
+    return [
+        {
+            "type": "text",
+            "name": "mov64_codec",
+            "text": "ap4h",
+        },
+        {
+            "type": "boolean",
+            "name": "mov64_write_timecode",
+            "boolean": True,
+        },
+    ]
+
+
 def _get_viewer_config_from_string(input_string):
     """Convert string to display and viewer string
 
@@ -314,6 +330,14 @@ def _convert_review_intermediates_model_0_4_11(overrides: dict) -> None:
 
         write_knobs = output.setdefault("write_knobs", {})
         write_knobs["file_type"] = extension
+        if extension != "mov":
+            continue
+
+        custom_knobs = write_knobs.get("custom")
+        if custom_knobs:
+            continue
+
+        write_knobs["custom"] = _get_custom_knobs_list()
 
 
 def convert_settings_overrides(

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -311,7 +311,8 @@ def _convert_review_intermediates_model_0_4_11(overrides: dict) -> None:
         if not extension:
             # Nothing to convert
             return
-        write_knobs = output.get("write_knobs")
+
+        write_knobs = output.setdefault("write_knobs", {})
         write_knobs["file_type"] = extension
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -203,7 +203,8 @@ class IntermediateOutputModel(BaseSettingsModel):
     )
     extension: str = SettingsField(
         "mov",
-        title="File extension"
+        title="File extension",
+        section="Representation definition",
     )
     add_custom_tags: list[str] = SettingsField(
         title="Custom tags",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -147,16 +147,22 @@ class ReformatNodesConfigModel(BaseSettingsModel):
 
 
 class WriteKnobsModel(BaseSettingsModel):
-    file_type: str = SettingsField(False)
+    file_type: str = SettingsField(default="mov", title="File type")
     custom: list[KnobModel] = SettingsField(
-        default_factory=list,
-        title="Additional Knobs"
+        title="Additional Knobs",
+        default=[
+            KnobModel(
+                type="text",
+                name="mov64_codec",
+                text="ap4h",
+            ),
+            KnobModel(
+                type="boolean",
+                name="mov64_write_timecode",
+                boolean=True,
+            )
+        ]
     )
-    @validator("custom")
-    def ensure_unique_names(cls, value):
-        """Ensure name fields within the lists have unique names."""
-        ensure_unique_names(value)
-        return value
 
 
 class IntermediateOutputModel(BaseSettingsModel):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -503,6 +503,8 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
                 "extension": "mov",
                 "custom_write_knobs": [
                     {"type": "text", "name": "file_type", "text": "mov"},
+                    {"type": "text", "name": "mov64_codec", "text": "ap4h"},
+                    {"type": "boolean", "name": "mov64_write_timecode", "boolean": True}  # noqa: E501
                 ],
                 "add_custom_tags": [],
                 "fill_missing_frames": "0"

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -146,6 +146,19 @@ class ReformatNodesConfigModel(BaseSettingsModel):
     )
 
 
+class WriteKnobsModel(BaseSettingsModel):
+    file_type: str = SettingsField(False)
+    custom: list[KnobModel] = SettingsField(
+        default_factory=list,
+        title="Additional Knobs"
+    )
+    @validator("custom")
+    def ensure_unique_names(cls, value):
+        """Ensure name fields within the lists have unique names."""
+        ensure_unique_names(value)
+        return value
+
+
 class IntermediateOutputModel(BaseSettingsModel):
     name: str = SettingsField(title="Output name")
     publish: bool = SettingsField(
@@ -157,6 +170,13 @@ class IntermediateOutputModel(BaseSettingsModel):
     read_raw: bool = SettingsField(
         False,
         title="Input read node RAW switch"
+    )
+    write_knobs: WriteKnobsModel = SettingsField(
+        default_factory=WriteKnobsModel,
+        title="Write Knobs",
+        description=(
+            "Configure knobs on the output write node"
+        )
     )
     bake_viewer_process: bool = SettingsField(
         True,
@@ -177,16 +197,6 @@ class IntermediateOutputModel(BaseSettingsModel):
         default_factory=ReformatNodesConfigModel,
         title="Reformat Nodes")
 
-    custom_write_knobs: list[KnobModel] = SettingsField(
-        default_factory=list,
-        title="Custom Write Knobs",
-        description=(
-            "Define custom write knobs to override default write node "
-            "settings. This is useful for user customization of write node "
-            "settings for their pipeline."
-        )
-    )
-
     add_custom_tags: list[str] = SettingsField(
         title="Custom tags",
         default_factory=list,
@@ -201,12 +211,6 @@ class IntermediateOutputModel(BaseSettingsModel):
         enum_resolver=_handle_missing_frames_enum,
         section="Representation definition",
     )
-
-    @validator("custom_write_knobs")
-    def ensure_unique_names(cls, value):
-        """Ensure name fields within the lists have unique names."""
-        ensure_unique_names(value)
-        return value
 
 
 class ExtractReviewIntermediatesModel(BaseSettingsModel):
@@ -483,11 +487,21 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
                         }
                     ]
                 },
-                "custom_write_knobs": [
-                    {"type": "text", "name": "file_type", "text": "mov"},
-                    {"type": "text", "name": "mov64_codec", "text": "ap4h"},
-                    {"type": "boolean", "name": "mov64_write_timecode", "boolean": True}  # noqa: E501
-                ],
+                "write_knobs": {
+                    "file_type": "mov",
+                    "custom": [
+                        {
+                            "type": "text",
+                            "name": "mov64_codec",
+                            "text": "ap4h",
+                        },
+                        {
+                            "type": "boolean",
+                            "name": "mov64_write_timecode",
+                            "boolean": True,
+                        },
+                    ],
+                },
                 "add_custom_tags": [],
                 "fill_missing_frames": "0"
             }

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -505,7 +505,7 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
                         }
                     ]
                 },
-                "output_type": "extension",
+                "output_type": "custom_write_knobs",
                 "extension": "mov",
                 "custom_write_knobs": [
                     {"type": "text", "name": "file_type", "text": "mov"},

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -199,6 +199,7 @@ class IntermediateOutputModel(BaseSettingsModel):
     custom_write_knobs: list[KnobModel] = SettingsField(
         default_factory=list,
         title="Custom Write Knobs",
+        section="Output definition",
     )
     extension: str = SettingsField(
         "mov",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -204,7 +204,6 @@ class IntermediateOutputModel(BaseSettingsModel):
     extension: str = SettingsField(
         "mov",
         title="File extension",
-        section="Representation definition",
     )
     add_custom_tags: list[str] = SettingsField(
         title="Custom tags",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -146,6 +146,18 @@ class ReformatNodesConfigModel(BaseSettingsModel):
     )
 
 
+def _intermediate_preset_output_types() -> list:
+    return [
+        {
+            "value": "extension",
+            "label": "Defined by extension"
+        },
+        {
+            "value": "custom_write_knobs",
+            "label": "Defined by custom write knobs"
+        }
+    ]
+
 class IntermediateOutputModel(BaseSettingsModel):
     name: str = SettingsField(title="Output name")
     publish: bool = SettingsField(
@@ -176,12 +188,27 @@ class IntermediateOutputModel(BaseSettingsModel):
     reformat_nodes_config: ReformatNodesConfigModel = SettingsField(
         default_factory=ReformatNodesConfigModel,
         title="Reformat Nodes")
+
+    output_type: str = SettingsField(
+        title="Output type",
+        default="extension",
+        enum_resolver=_intermediate_preset_output_types,
+        conditional_enum=True,
+        section="Output definition",
+    )
+    custom_write_knobs: list[KnobModel] = SettingsField(
+        default_factory=list,
+        title="Custom Write Knobs",
+    )
     extension: str = SettingsField(
         "mov",
         title="File extension"
     )
     add_custom_tags: list[str] = SettingsField(
-        title="Custom tags", default_factory=list)
+        title="Custom tags",
+        default_factory=list,
+        section="Representation definition",
+    )
 
     fill_missing_frames:str = SettingsField(
         title="Handle missing frames",
@@ -190,6 +217,12 @@ class IntermediateOutputModel(BaseSettingsModel):
                     "Used for filling gaps for Custom Frames",
         enum_resolver=_handle_missing_frames_enum
     )
+
+    @validator("custom_write_knobs")
+    def ensure_unique_names(cls, value):
+        """Ensure name fields within the lists have unique names."""
+        ensure_unique_names(value)
+        return value
 
 
 class ExtractReviewIntermediatesModel(BaseSettingsModel):
@@ -466,7 +499,11 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
                         }
                     ]
                 },
+                "output_type": "extension",
                 "extension": "mov",
+                "custom_write_knobs": [
+                    {"type": "text", "name": "file_type", "text": "mov"},
+                ],
                 "add_custom_tags": [],
                 "fill_missing_frames": "0"
             }

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -199,7 +199,11 @@ class IntermediateOutputModel(BaseSettingsModel):
     custom_write_knobs: list[KnobModel] = SettingsField(
         default_factory=list,
         title="Custom Write Knobs",
-        section="Output definition",
+        description=(
+            "Define custom write knobs to override default write node "
+            "settings. This is useful for user customization of write node "
+            "settings for their pipeline."
+        )
     )
     extension: str = SettingsField(
         "mov",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -209,7 +209,6 @@ class IntermediateOutputModel(BaseSettingsModel):
         description="What to do about missing frames from entity frame range."
                     "Used for filling gaps for Custom Frames",
         enum_resolver=_handle_missing_frames_enum,
-        section="Representation definition",
     )
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -217,7 +217,8 @@ class IntermediateOutputModel(BaseSettingsModel):
         default="0",
         description="What to do about missing frames from entity frame range."
                     "Used for filling gaps for Custom Frames",
-        enum_resolver=_handle_missing_frames_enum
+        enum_resolver=_handle_missing_frames_enum,
+        section="Representation definition",
     )
 
     @validator("custom_write_knobs")

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -146,18 +146,6 @@ class ReformatNodesConfigModel(BaseSettingsModel):
     )
 
 
-def _intermediate_preset_output_types() -> list:
-    return [
-        {
-            "value": "extension",
-            "label": "Defined by extension"
-        },
-        {
-            "value": "custom_write_knobs",
-            "label": "Defined by custom write knobs"
-        }
-    ]
-
 class IntermediateOutputModel(BaseSettingsModel):
     name: str = SettingsField(title="Output name")
     publish: bool = SettingsField(
@@ -189,13 +177,6 @@ class IntermediateOutputModel(BaseSettingsModel):
         default_factory=ReformatNodesConfigModel,
         title="Reformat Nodes")
 
-    output_type: str = SettingsField(
-        title="Output type",
-        default="extension",
-        enum_resolver=_intermediate_preset_output_types,
-        conditional_enum=True,
-        section="Output definition",
-    )
     custom_write_knobs: list[KnobModel] = SettingsField(
         default_factory=list,
         title="Custom Write Knobs",
@@ -205,10 +186,7 @@ class IntermediateOutputModel(BaseSettingsModel):
             "settings for their pipeline."
         )
     )
-    extension: str = SettingsField(
-        "mov",
-        title="File extension",
-    )
+
     add_custom_tags: list[str] = SettingsField(
         title="Custom tags",
         default_factory=list,
@@ -505,8 +483,6 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
                         }
                     ]
                 },
-                "output_type": "custom_write_knobs",
-                "extension": "mov",
                 "custom_write_knobs": [
                     {"type": "text", "name": "file_type", "text": "mov"},
                     {"type": "text", "name": "mov64_codec", "text": "ap4h"},


### PR DESCRIPTION
Introduces an `output_type` field on `IntermediateOutputModel` to choose between file-extension or custom write knobs. Includes a validator that enforces unique names on the knob list and reorganizes fields into their own sections.

## Changelog Description
Adds output type selection (extension vs custom write knobs) for intermediate presets. The new `output_type` field determines how output is written, with a fallback to "Defined by extension". Includes a validator ensuring unique names in the custom write knobs list and a reformat-nodes config that stores its data as a subfolder of representation files.

## Additional review information
The changes focus on:

- **New `output_type` field** — A new enum-like resolver with two preset values ("Defined by extension", "Defined by custom write knobs") is added to the model, defaulting to extension. The corresponding data in the reformat nodes config is stored as a subfolder of representation files and written via `CustomWriteKnobsManager` for proper serialization.

- **Validation** — A validator on the `custom_write_knobs` list ensures unique names are preserved at runtime.

- **UI organization** — Related fields (output_type, custom_write_knobs) live under "Output definition" and add_custom_tags/extension/fill_missing_frames stay under "Representation definition".

## Testing notes:
1. Open intermediate preset editor and verify the new "Output type" dropdown appears
2. Test creating an intermediate with output_type set to custom write knobs and confirm `CustomWriteKnobsManager` serialization works correctly
3. Test validation by adding duplicate names in the knob list
4. Verify reformat-nodes data is written as subfolder of representation files

## Dependency
Close [ynput/ayon-nuke#343](https://github.com/ynput/ayon-nuke/issues/343)

## Related support tickets
[YN-0771](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=folder&id=d77a263b20fc4e6b89da97b1f1ea7e91)

