### PR TITLE
Respect display and view in ExporterReview

### DIFF
--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1473,7 +1473,7 @@ class ExporterReviewMov(ExporterReview):
         if delete:
             tags.append("delete")
 
-        if config_data and not display:
+        if config_data and (not colorspace and not display):
             # backward compatibility: convert display and view to colorspace
             # just in case older nuke_default ocio config
             colorspace = get_display_view_colorspace_name(

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1473,7 +1473,7 @@ class ExporterReviewMov(ExporterReview):
         if delete:
             tags.append("delete")
 
-        if not display:
+        if config_data and not display:
             # backward compatibility: convert display and view to colorspace
             # just in case older nuke_default ocio config
             colorspace = get_display_view_colorspace_name(

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -1020,6 +1020,7 @@ class ExporterReview(object):
                 "display": display,
                 "view": view,
             })
+
         self.data["representations"].append(repre)
 
     def get_imageio_baking_profile(self):
@@ -1471,6 +1472,15 @@ class ExporterReviewMov(ExporterReview):
 
         if delete:
             tags.append("delete")
+
+        if not display:
+            # backward compatibility: convert display and view to colorspace
+            # just in case older nuke_default ocio config
+            colorspace = get_display_view_colorspace_name(
+                config_path=config_data["path"],
+                display=display,
+                view=view
+            )
 
         self.get_representation_data(
             tags=tags + add_tags,

--- a/client/ayon_nuke/api/plugin.py
+++ b/client/ayon_nuke/api/plugin.py
@@ -947,18 +947,24 @@ class ExporterReview(object):
         range=False,
         custom_tags=None,
         colorspace=None,
+        display=None,
+        view=None,
     ):
-        """Add representation data to self.data
+        """Add representation data to self.data.
 
         Args:
             tags (list[str], optional): list of defined tags.
-                                        Defaults to None.
+                Defaults to None.
             range (bool, optional): flag for adding ranges.
-                                    Defaults to False.
+                Defaults to False.
             custom_tags (list[str], optional): user inputted custom tags.
-                                               Defaults to None.
+                Defaults to None.
             colorspace (str, optional): colorspace name.
-                                        Defaults to None.
+                Defaults to None.
+            display (str, optional): display name.
+                Defaults to None.
+            view (str, optional): view name.
+                Defaults to None.
         """
         add_tags = tags or []
         repre = {
@@ -1001,6 +1007,19 @@ class ExporterReview(object):
                 colorspace=colorspace,
                 log=self.log
             )
+        elif display and view:
+            set_colorspace_data_to_representation(
+                repre,
+                self.instance.context.data,
+                colorspace=display,
+                log=self.log
+            )
+            # remove colorspace key from colorspaceData
+            repre["colorspaceData"].pop("colorspace", None)
+            repre["colorspaceData"].update({
+                "display": display,
+                "view": view,
+            })
         self.data["representations"].append(repre)
 
     def get_imageio_baking_profile(self):
@@ -1256,6 +1275,8 @@ class ExporterReviewMov(ExporterReview):
     def generate_mov(self, farm=False, delete=True, **kwargs):
         # colorspace data
         colorspace = self.write_colorspace
+        display = None
+        view = None
 
         # get colorspace settings
         # get colorspace data from context
@@ -1351,12 +1372,7 @@ class ExporterReviewMov(ExporterReview):
 
                     node["view"].setValue(view)
 
-                    if config_data:
-                        # convert display and view to colorspace
-                        colorspace = get_display_view_colorspace_name(
-                            config_path=config_data["path"],
-                            display=display, view=view
-                        )
+                    colorspace = None
 
                 # OCIOColorSpace
                 elif baking_colorspace["type"] == "colorspace":
@@ -1461,6 +1477,8 @@ class ExporterReviewMov(ExporterReview):
             custom_tags=add_custom_tags,
             range=True,
             colorspace=colorspace,
+            display=display,
+            view=view,
         )
 
         self.log.debug(f"Representation...   `{self.data}`")


### PR DESCRIPTION
## Changelog Description
ExporterReview now preserves OCIO display and view data separately when baking reviews in Nuke. This enables downstream integration to derive the correct colorspace template value for display/view transforms instead of losing the selected view metadata.

## Additional info
Representation colorspace data now accepts `display` and `view`. The dependent `ayon-core` change derives the integration template value from these fields when no direct colorspace is available.

## Testing notes:
At your Intermediate baking preset use dispaly and view from your active OCIO config. Ideally test at ACES 1.3.
The outcome should look as expected.


## Dependency
Depends on https://github.com/ynput/ayon-core/pull/1983
