### PR TITLE
POC: Use ipc utils to show tools

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -25,7 +25,7 @@ from ayon_core.lib import (
     BoolDef,
     UILabelDef,
 )
-
+from ayon_core.tools.ipc_utils import IPCHostTools
 from ayon_core.tools.attribute_defs.dialog import (
     AttributeDefinitionsDialog
 )
@@ -2622,8 +2622,7 @@ def _launch_workfile_app():
     #   - this happened on Centos 7 and it is because the focus of nuke
     #       changes to the main window after showing because of initialization
     #       which moves workfiles tool under it
-    from ayon_core.tools.utils import host_tools
-    host_tools.show_workfiles(parent=None, on_top=True)
+    IPCHostTools.show_workfiles()
 
 
 def update_content_on_context_change():

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -55,9 +55,6 @@ from ayon_core.tools.ipc_utils.utils import (
     start_main_thread_helper,
     execute_in_main_thread,
 )
-from ayon_core.tools.workfiles.ipc_backend_control import IPCWorkfilesBackend
-from ayon_core.tools.loader.ipc_backend_control import IPCLoaderBackend
-from ayon_core.tools.publisher.ipc_backend_control import IPCPublisherBackend
 from .lib import (
     Context,
     ROOT_DATA_KNOB,
@@ -170,9 +167,6 @@ class NukeHost(
         launch_workfiles_app()
 
         IPCHostTools.init()
-        IPCHostTools.set_loader_backend(IPCLoaderBackend(self))
-        IPCHostTools.set_publisher_backend(IPCPublisherBackend(self))
-        IPCHostTools.set_workfiles_backend(IPCWorkfilesBackend(self))
         start_main_thread_helper()
 
         def _tick():

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -166,7 +166,7 @@ class NukeHost(
         add_scripts_gizmo()
         launch_workfiles_app()
 
-        IPCHostTools.init()
+        IPCHostTools.init(host=self)
         start_main_thread_helper()
 
         def _tick():

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -54,7 +54,6 @@ from ayon_core.tools.ipc_utils import IPCHostTools
 from ayon_core.tools.ipc_utils.utils import (
     start_main_thread_helper,
     execute_in_main_thread,
-    WrappedCallbackItem,
 )
 from ayon_core.tools.workfiles.ipc_backend_control import IPCWorkfilesBackend
 from ayon_core.tools.loader.ipc_backend_control import IPCLoaderBackend

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import nuke
 
-import os
-import importlib
 from collections import OrderedDict, defaultdict
+import importlib
+import os
+from typing import Any
 
 import pyblish.api
 
@@ -47,6 +50,15 @@ except ImportError:
         version_up_current_workfile as save_next_version
     )
 
+from ayon_core.tools.ipc_utils import IPCHostTools
+from ayon_core.tools.ipc_utils.utils import (
+    start_main_thread_helper,
+    execute_in_main_thread,
+    WrappedCallbackItem,
+)
+from ayon_core.tools.workfiles.ipc_backend_control import IPCWorkfilesBackend
+from ayon_core.tools.loader.ipc_backend_control import IPCLoaderBackend
+from ayon_core.tools.publisher.ipc_backend_control import IPCPublisherBackend
 from .lib import (
     Context,
     ROOT_DATA_KNOB,
@@ -157,6 +169,21 @@ class NukeHost(
         add_scripts_menu()
         add_scripts_gizmo()
         launch_workfiles_app()
+
+        IPCHostTools.init()
+        IPCHostTools.set_loader_backend(IPCLoaderBackend(self))
+        IPCHostTools.set_publisher_backend(IPCPublisherBackend(self))
+        IPCHostTools.set_workfiles_backend(IPCWorkfilesBackend(self))
+        start_main_thread_helper()
+
+        def _tick():
+            IPCHostTools.process_requests()
+            execute_in_main_thread(_tick)
+
+        execute_in_main_thread(_tick)
+
+    def execute_in_main_thread(self, func, *args, **kwargs) -> Any:
+        return nuke.executeInMainThreadWithResult(func, (), kwargs)
 
     def get_context_data(self):
         root_node = nuke.root()
@@ -369,16 +396,9 @@ def _install_menu(project_settings: dict):
             shortcut_str
         )
 
-    def _show_workfiles():
-        # Make sure parent is not set
-        # - this makes Workfiles tool as separated window which
-        #   avoid issues with reopening
-        # - it is possible to explicitly change on top flag of the tool
-        host_tools.show_workfiles(parent=None, on_top=False)
-
     menu.addCommand(
         "Work Files...",
-        _show_workfiles
+        IPCHostTools.show_workfiles
     )
 
     menu.addSeparator()
@@ -387,8 +407,7 @@ def _install_menu(project_settings: dict):
         # known issue with no solution yet
         menu.addCommand(
             "Create...",
-            lambda: host_tools.show_publisher(
-                parent=main_window,
+            lambda: IPCHostTools.show_publisher(
                 tab="create"
             )
         )
@@ -396,18 +415,12 @@ def _install_menu(project_settings: dict):
         # known issue with no solution yet
         menu.addCommand(
             "Publish...",
-            lambda: host_tools.show_publisher(
-                parent=main_window,
-                tab="publish"
-            )
+            IPCHostTools.show_publisher
         )
 
     menu.addCommand(
         "Load...",
-        lambda: host_tools.show_loader(
-            parent=main_window,
-            use_context=True
-        )
+        IPCHostTools.show_loader
     )
     menu.addCommand(
         "Manage...",


### PR DESCRIPTION
## Changelog Description
Use IPC utils to show tools in nuke.

## Additional review information
This PR is for a prove of concept of IPC implementation in ayon-core https://github.com/ynput/ayon-core/pull/1987 .

## Testing notes:
1. Workfiles, loader and publisher tools do work.
