### PR TITLE
Do not error on `CollectSyncWorkfileVersion` if current file is unsaved

### DIFF
--- a/client/ayon_nuke/plugins/publish/collect_sync_workfile_version.py
+++ b/client/ayon_nuke/plugins/publish/collect_sync_workfile_version.py
@@ -26,8 +26,8 @@ class CollectSyncWorkfileVersion(pyblish.api.InstancePlugin):
         if "version" not in context.data:
             # This may happen is workfile is not saved
             self.log.error(
-                "Unable to sync workfile version, because no context version "
-                "was found. Make sure workfile is saved."
+                "Unable to sync workfile version because no context version "
+                "was found. Make sure the workfile is saved."
             )
             return
 

--- a/client/ayon_nuke/plugins/publish/collect_sync_workfile_version.py
+++ b/client/ayon_nuke/plugins/publish/collect_sync_workfile_version.py
@@ -25,7 +25,7 @@ class CollectSyncWorkfileVersion(pyblish.api.InstancePlugin):
         context = instance.context
         if "version" not in context.data:
             # This may happen is workfile is not saved
-            self.log.error(
+            self.log.warning(
                 "Unable to sync workfile version because no context version "
                 "was found. Make sure the workfile is saved."
             )

--- a/client/ayon_nuke/plugins/publish/collect_sync_workfile_version.py
+++ b/client/ayon_nuke/plugins/publish/collect_sync_workfile_version.py
@@ -19,9 +19,20 @@ class CollectSyncWorkfileVersion(pyblish.api.InstancePlugin):
     def process(self, instance: pyblish.api.Instance):
         product_base_type: str = instance.data["productBaseType"]
         # sync workfile version
-        if product_base_type in self.sync_workfile_version_on_product_base_types:  # noqa: E501
-            self.log.debug(
-                f"Syncing version with workfile for '{product_base_type}'"
+        if product_base_type not in self.sync_workfile_version_on_product_base_types:  # noqa: E501
+            return
+
+        context = instance.context
+        if "version" not in context.data:
+            # This may happen is workfile is not saved
+            self.log.error(
+                "Unable to sync workfile version, because no context version "
+                "was found. Make sure workfile is saved."
             )
-            # get version to instance for integration
-            instance.data['version'] = instance.context.data['version']
+            return
+
+        self.log.debug(
+            f"Syncing version with workfile for '{product_base_type}'"
+        )
+        # get version to instance for integration
+        instance.data['version'] = context.data['version']


### PR DESCRIPTION
## Changelog Description

Do not error on `CollectSyncWorkfileVersion` if current file is unsaved

## Additional review information

Fix https://discord.com/channels/517362899170230292/1537136809111326790

Now stops on validation:
<img width="1319" height="838" alt="image" src="https://github.com/user-attachments/assets/a4aceeca-de29-450b-bf7a-93d2db9f0411" />



## Testing notes:

1. Publishing render without having your comp saved should not error during Collector stage