### PR TITLE
Add `check_inventory_version` in create and load callback function

### DIFF
--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -242,29 +242,33 @@ def add_nuke_callbacks(project_settings: dict = None):
 
 
 def on_root_create() -> None:
-    """Callback function for on script create."""
-    # set apply all workfile settings on script load and save
-    workfile_settings = WorkfileSettings()
-    on_script_create_settings = (
-        workfile_settings.project_settings
-        ["nuke"]
-        ["workfile_callbacks"]
-        ["on_script_create"]
-    )
-
-    if on_script_create_settings["set_resolution"]:
-        workfile_settings.reset_resolution()
-
-    if on_script_create_settings["set_frame_range"]:
-        workfile_settings.reset_frame_range_handles()
-
-    if on_script_create_settings["set_colorspace"]:
-        workfile_settings.set_colorspace()
-
+    """Callback function for on root node create."""
     # adding favorites to file browser
+    workfile_settings = WorkfileSettings()
     workfile_settings.set_favorites()
-    # template builder callbacks
-    start_workfile_template_builder()
+
+    # Root created callback is also triggered on scene load because that also
+    # creates a new root node. So we check if current file is None to run
+    # logic that we only want to apply on new scene creation.
+    if current_file() is None:
+        on_script_create_settings = (
+            workfile_settings.project_settings
+            ["nuke"]
+            ["workfile_callbacks"]
+            ["on_script_create"]
+        )
+
+        if on_script_create_settings["set_resolution"]:
+            workfile_settings.reset_resolution()
+
+        if on_script_create_settings["set_frame_range"]:
+            workfile_settings.reset_frame_range_handles()
+
+        if on_script_create_settings["set_colorspace"]:
+            workfile_settings.set_colorspace()
+
+        # template builder callbacks
+        start_workfile_template_builder()
 
 
 def on_script_load() -> None:

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -1,7 +1,6 @@
 import nuke
 
 import os
-import contextlib
 import importlib
 from collections import OrderedDict, defaultdict
 
@@ -18,7 +17,7 @@ from ayon_core.host import (
 
 from ayon_core.host.interfaces import SaveWorkfileContext
 
-from ayon_core.lib import register_event_callback, Logger
+from ayon_core.lib import Logger
 from ayon_core.pipeline import (
     register_loader_plugin_path,
     register_creator_plugin_path,

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -226,11 +226,8 @@ def add_nuke_callbacks(project_settings: dict = None):
 
     nuke_settings = project_settings["nuke"]
 
-    # Set all workfile settings.'
     nuke.addOnCreate(on_root_create, nodeClass="Root")
-    # set checker for last versions on loaded containers
-    nuke.addOnScriptLoad(check_inventory_versions)
-    # fix ffmpeg settings on script
+
     nuke.addOnScriptLoad(on_script_load)
 
     # set checker for last versions on loaded containers
@@ -268,6 +265,8 @@ def on_root_create() -> None:
     workfile_settings.set_favorites()
     # template builder callbacks
     start_workfile_template_builder()
+    # set checker for last versions on loaded containers
+    check_inventory_versions()
 
 
 def on_script_load() -> None:
@@ -297,6 +296,9 @@ def on_script_load() -> None:
 
     if on_script_load_settings["set_colorspace"]:
         workfile_settings.set_colorspace()
+
+    # set checker for last versions on loaded containers
+    check_inventory_versions()
 
 
 def reload_config():

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -239,7 +239,6 @@ def add_nuke_callbacks(project_settings: dict = None):
 
 def on_root_create() -> None:
     """Callback function for on root node create."""
-    log.info("On root create...")
     # adding favorites to file browser
     workfile_settings = WorkfileSettings()
     workfile_settings.set_favorites()

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -164,7 +164,6 @@ class NukeHost(
         root_node = nuke.root()
         set_node_data(root_node, ROOT_DATA_KNOB, data)
 
-
     def _before_workfile_save(
         self, save_workfile_context: SaveWorkfileContext
     ) -> None:

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -265,8 +265,6 @@ def on_root_create() -> None:
     workfile_settings.set_favorites()
     # template builder callbacks
     start_workfile_template_builder()
-    # set checker for last versions on loaded containers
-    check_inventory_versions()
 
 
 def on_script_load() -> None:

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -1,6 +1,7 @@
 import nuke
 
 import os
+import contextlib
 import importlib
 from collections import OrderedDict, defaultdict
 
@@ -142,9 +143,6 @@ class NukeHost(
         register_inventory_action_path(INVENTORY_PATH)
         register_workfile_build_plugin_path(WORKFILE_BUILD_PATH)
 
-        # Register AYON event for workfiles loading.
-        register_event_callback("workio.open_file", check_inventory_versions)
-
     def setup_ui_callbacks_and_menu(self):
         """Setup AYON menus."""
         if not nuke.GUI:
@@ -243,6 +241,7 @@ def add_nuke_callbacks(project_settings: dict = None):
 
 def on_root_create() -> None:
     """Callback function for on root node create."""
+    log.info("On root create...")
     # adding favorites to file browser
     workfile_settings = WorkfileSettings()
     workfile_settings.set_favorites()
@@ -251,6 +250,7 @@ def on_root_create() -> None:
     # creates a new root node. So we check if current file is None to run
     # logic that we only want to apply on new scene creation.
     if current_file() is None:
+        log.info("On new file..")
         on_script_create_settings = (
             workfile_settings.project_settings
             ["nuke"]
@@ -273,6 +273,7 @@ def on_root_create() -> None:
 
 def on_script_load() -> None:
     """Callback function for on script load."""
+    log.info("On script load...")
     # fix ffmpeg settings on script
     if nuke.env["LINUX"]:
         nuke.tcl('load ffmpegReader')

--- a/client/ayon_nuke/api/pipeline.py
+++ b/client/ayon_nuke/api/pipeline.py
@@ -247,7 +247,6 @@ def on_root_create() -> None:
     # creates a new root node. So we check if current file is None to run
     # logic that we only want to apply on new scene creation.
     if current_file() is None:
-        log.info("On new file..")
         on_script_create_settings = (
             workfile_settings.project_settings
             ["nuke"]

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -30,6 +30,10 @@ def open_file(filepath):
             nuke.Root()["name"].setValue(nuke_script)
             nuke.Root()["project_directory"].setValue(os.path.dirname(nuke_script))
             nuke.Root().setModified(False)
+
+            # Above way of loading script does not trigger onScriptLoad()
+            # callback, so we need to call it manually
+            nuke.onScriptLoad()
         else:
             nuke.scriptOpen(nuke_script)
 

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -8,7 +8,7 @@ from .constants import ASSIST
 
 @contextlib.contextmanager
 def _no_script_create_callbacks():
-    """Context manager to temporarily disable on_script_create callbacks."""
+    """Context manager to temporarily disable `nuke.onCreate` callbacks."""
     callbacks = nuke.onCreates.copy()
     try:
         nuke.onCreates.clear()

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -1,8 +1,20 @@
 """Host API required Work Files tool"""
 import os
+import contextlib
 import nuke
 import shutil
 from .constants import ASSIST
+
+
+@contextlib.contextmanager
+def _no_script_create_callbacks():
+    """Context manager to temporarily disable on_script_create callbacks."""
+    callbacks = nuke.onCreates.copy()
+    try:
+        nuke.onCreates.clear()
+        yield
+    finally:
+        nuke.onCreates = callbacks
 
 
 def file_extensions():
@@ -25,7 +37,8 @@ def open_file(filepath):
 
     def read_script(nuke_script):
         if not ASSIST:
-            nuke.scriptClear()
+            with _no_script_create_callbacks():
+                nuke.scriptClear()
             nuke.scriptReadFile(nuke_script)
             nuke.Root()["name"].setValue(nuke_script)
             nuke.Root()["project_directory"].setValue(os.path.dirname(nuke_script))

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -14,7 +14,7 @@ def _no_create_callbacks():
         nuke.onCreates.clear()
         yield
     finally:
-        nuke.onCreates = callbacks
+        nuke.onCreates.update(callbacks)
 
 
 def file_extensions():

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -33,6 +33,26 @@ def save_file(filepath):
     nuke.Root().setModified(False)
 
 
+def _get_autosave_filepath(filepath: str) -> str | None:
+    """Query autosave file path for a given file path, by evaluating the
+    autosave name preferences with root name temporarily set to the given
+    file path.
+
+    This allows us to get the autosave path for a file that is not currently
+    open in Nuke.
+    """
+    root = nuke.Root()
+    original_name = root.name()
+    root["name"].setValue(filepath)
+    try:
+        autosave = nuke.toNode("preferences")["AutoSaveName"].evaluate()
+        if os.path.isfile(autosave):
+            return autosave
+        return None
+    finally:
+        root["name"].setValue(original_name)
+
+
 def open_file(filepath):
 
     def read_script(nuke_script):
@@ -58,26 +78,24 @@ def open_file(filepath):
 
     filepath = filepath.replace("\\", "/")
 
-    # To remain in the same window, we have to clear the script and read
-    # in the contents of the workfile.
-    # Nuke Preferences can be read after the script is read.
-    read_script(filepath)
-
-    if nuke.GUI:
-        autosave = nuke.toNode("preferences")["AutoSaveName"].evaluate()
-        autosave_prmpt = "Autosave detected.\n" \
-                         "Would you like to load the autosave file?"  # noqa
-        if os.path.isfile(autosave) and nuke.ask(autosave_prmpt):
+    # Before opening the file, see if it has an autosave file and ask the user
+    # if they want to load it instead.
+    if nuke.GUI and (autosave := _get_autosave_filepath(filepath)):
+        if nuke.ask(
+            "Autosave detected.\n"
+            "Would you like to load the autosave file?"
+        ):
             try:
                 # Overwrite the filepath with autosave
                 shutil.copy(autosave, filepath)
-                # Now read the (auto-saved) script again
-                read_script(filepath)
             except shutil.Error as err:
                 nuke.message(
-                    "Detected autosave file could not be used.\n{}"
+                    f"Detected autosave file could not be used.\n{err}"
+                )
 
-                    .format(err))
+    # To remain in the same window, we have to clear the script and read
+    # in the contents of the workfile.
+    read_script(filepath)
 
     return True
 

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -95,8 +95,13 @@ def open_file(filepath):
                     f"Detected autosave file could not be used.\n{err}"
                 )
 
-    # To remain in the same window, we have to clear the script and read
-    # in the contents of the workfile.
+    # Load the script into the current Nuke session.
+    # This uses read_script() which replaces the current script content
+    # in the same window. However, when a GUI is active and an autosave
+    # exists, the user is prompted to load the autosave instead - which
+    # is then copied over the original file before read_script() executes.
+    # The "same window" behavior applies only when the GUI is not active
+    # or when no autosave prompt is shown.
     read_script(filepath)
 
     return True

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -40,12 +40,18 @@ def open_file(filepath):
             with _no_create_callbacks():
                 nuke.scriptClear()
             nuke.scriptReadFile(nuke_script)
-            nuke.Root()["name"].setValue(nuke_script)
-            nuke.Root()["project_directory"].setValue(os.path.dirname(nuke_script))
-            nuke.Root().setModified(False)
 
-            # Above way of loading script does not trigger onScriptLoad()
-            # callback, so we need to call it manually
+            root = nuke.Root()
+            root["name"].setValue(nuke_script)
+            root["project_directory"].setValue(os.path.dirname(nuke_script))
+            root.setModified(False)
+
+            # Above way of loading script does not trigger onCreate() nor
+            # onScriptLoad() callback, so we need to call it manually here
+            # after root name has been set so the callbacks behave similar
+            # to how they would if user would do File > Open or on Nuke
+            # launch with a comp script file.
+            nuke.onCreate()
             nuke.onScriptLoad()
         else:
             nuke.scriptOpen(nuke_script)

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -58,6 +58,8 @@ def _get_autosave_filepath(filepath: str) -> str | None:
 def open_file(filepath):
 
     def read_script(nuke_script):
+        # Nuke Assist does not support clearing and reading a script into the
+        # current session, so it must use scriptOpen() instead.
         if not ASSIST:
             with _no_create_callbacks():
                 nuke.scriptClear()
@@ -95,13 +97,6 @@ def open_file(filepath):
                     f"Detected autosave file could not be used.\n{err}"
                 )
 
-    # Load the script into the current Nuke session.
-    # This uses read_script() which replaces the current script content
-    # in the same window. However, when a GUI is active and an autosave
-    # exists, the user is prompted to load the autosave instead - which
-    # is then copied over the original file before read_script() executes.
-    # The "same window" behavior applies only when the GUI is not active
-    # or when no autosave prompt is shown.
     read_script(filepath)
 
     return True

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -1,4 +1,6 @@
 """Host API required Work Files tool"""
+from __future__ import annotations
+
 import os
 import contextlib
 import nuke

--- a/client/ayon_nuke/api/workio.py
+++ b/client/ayon_nuke/api/workio.py
@@ -7,7 +7,7 @@ from .constants import ASSIST
 
 
 @contextlib.contextmanager
-def _no_script_create_callbacks():
+def _no_create_callbacks():
     """Context manager to temporarily disable `nuke.onCreate` callbacks."""
     callbacks = nuke.onCreates.copy()
     try:
@@ -37,7 +37,7 @@ def open_file(filepath):
 
     def read_script(nuke_script):
         if not ASSIST:
-            with _no_script_create_callbacks():
+            with _no_create_callbacks():
                 nuke.scriptClear()
             nuke.scriptReadFile(nuke_script)
             nuke.Root()["name"].setValue(nuke_script)


### PR DESCRIPTION
## Changelog Description
This PR is to add `check_inventory_version` in create and load callback function to ensure the check_inventory_version would apply when the nuke session is opened via workfile tools.

## Additional review information
Fix https://github.com/ynput/ayon-nuke/issues/352#

## Testing notes:
1. Launch Nuke 
2. Load something with not the latest version
3. Save your scene via workfile tools(SceneA)
4. Updated to the latest version to your loaded asset
5. Save your scene via workfile tools (SceneB)
6. Open your Scene A back via workfile tools
7. It should be showing the correct color.
