### PR TITLE
Setting conversion: Fix UnboundLocalError on `extract_review_intermediates` variable

### DIFF
--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -110,11 +110,13 @@ def _convert_extract_intermediate_files_0_2_3(publish_overrides):
 
     0.2.2. is the latest version using the old way.
     """
-    # override can be either `display/view` or `view (display)`
-    if "ExtractReviewIntermediates" in publish_overrides:
-        extract_review_intermediates = publish_overrides[
-            "ExtractReviewIntermediates"]
+    if "ExtractReviewIntermediates" not in publish_overrides:
+        return
 
+    extract_review_intermediates = publish_overrides[
+        "ExtractReviewIntermediates"
+    ]
+    # override can be either `display/view` or `view (display)`
     for output in extract_review_intermediates.get("outputs", []):
         if viewer_process_override := output.get("viewer_process_override"):
             display, view = _get_viewer_config_from_string(


### PR DESCRIPTION
## Changelog Description

Setting conversion: Fix #354 UnboundLocalError on `extract_review_intermediates` variable

## Additional review information

Settings conversion should work.

## Testing notes:

1. Copy settings from an older Nuke addon version that does **not** have overrides to `ExtractReviewIntermediates` but DOES have overrides to other plug-ins under `publish` section.
2. Settings copy should work.