### PR TITLE
Settings: Fix conversion if lack of overrides on `ExtractReviewIntermediates`

### DIFF
--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -312,6 +312,9 @@ def _convert_review_intermediates_model_0_4_11(
         .get("ExtractReviewIntermediates", {})
         .get("outputs")
     )
+    if not extract_review_outputs:
+        return
+
     for output in extract_review_outputs:
         extension = output.pop("extension", None)
         if not extension:


### PR DESCRIPTION
## Changelog Description

Avoid `TypeError: 'NoneType' object is not iterable` there were no previous overrides to `ExtractReviewIntermediates`

## Additional review information

Fix #354 

## Testing notes:

1. Should fix settings conversions from versions below 0.4.11 that do not have any overrides to `ExtractReviewIntermediates`