### PR TITLE
[YN-0692] Write node button: Single frame padding for image product

### DIFF
--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -1304,9 +1304,6 @@ def create_write_node(
 
             else:
                 # add linked knob by _k_name
-                if _k_name not in write_node.knobs():
-                    log.warning("Cannot expose missing Write knob: %s", _k_name)
-                    continue
                 link = nuke.Link_Knob("")
                 link.makeLink(write_node.name(), _k_name)
                 link.setName(_k_name)

--- a/client/ayon_nuke/api/lib.py
+++ b/client/ayon_nuke/api/lib.py
@@ -998,6 +998,24 @@ def script_name() -> str:
     return nuke.root().knob("name").value()
 
 
+def add_button_render_single_image(node: nuke.Node) -> None:
+    """Add a button to render a single image for the given node.
+
+    Args:
+        node (nuke.Node): The node for which the render single image
+        button is being added.
+    """
+    name = "Render"
+    label = "Render Local"
+    value = (
+        "from ayon_nuke.api.utils import render_single_frame;"
+        "render_single_frame(nuke.thisNode())"
+    )
+    knob = nuke.PyScript_Knob(name, label, value)
+    knob.clearFlag(nuke.STARTLINE)
+    node.addKnob(knob)
+
+
 def add_button_render_on_farm(node):
     name = "renderOnFarm"
     label = "Render On Farm"
@@ -1280,8 +1298,15 @@ def create_write_node(
             if "___" in _k_name:
                 # add divider
                 GN.addKnob(nuke.Text_Knob(""))
+
+            elif  _k_name == "Render" and plugin_name == "CreateWriteImage":
+                add_button_render_single_image(GN)
+
             else:
                 # add linked knob by _k_name
+                if _k_name not in write_node.knobs():
+                    log.warning("Cannot expose missing Write knob: %s", _k_name)
+                    continue
                 link = nuke.Link_Knob("")
                 link.makeLink(write_node.name(), _k_name)
                 link.setName(_k_name)

--- a/client/ayon_nuke/api/utils.py
+++ b/client/ayon_nuke/api/utils.py
@@ -10,6 +10,18 @@ from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.create import CreateContext
 
 
+def render_single_frame(group_node: nuke.Node) -> None:
+    """Render a single frame for the given group node.
+
+    Args:
+        group_node (nuke.Node): The group node containing the write
+        node to render.
+    """
+    write_node = nuke.allNodes("Write", group=group_node)[0]
+    frame = int(write_node["first"].value())
+    nuke.execute(write_node.fullName(), frame, frame)
+
+
 def set_context_favorites(favorites=None):
     """Adding favorite folders to nuke's browser
 

--- a/client/ayon_nuke/startup/write_to_read.py
+++ b/client/ayon_nuke/startup/write_to_read.py
@@ -74,6 +74,7 @@ def detect_file_on_disk(
     collections, _ = clique.assemble(
         [combined_relative_path],
         assume_padded_when_ambiguous=True,
+        minimum_items=1,
         patterns=[clique.PATTERNS['frames']]
     )
 
@@ -88,26 +89,20 @@ def detect_file_on_disk(
 
         if files_in_dir:
             # Assemble all files in directory to find the complete sequence
-            coll, _ = clique.assemble(
+            coll = clique.assemble(
                 files_in_dir,
                 assume_padded_when_ambiguous=True,
                 patterns=[clique.PATTERNS['frames']]
             )[0][0]
             if coll.padding == collection.padding:
                 # Found matching sequence
-                directory_path = os.path.dirname(k_value)
-                basename = coll.head
-                extension = coll.tail
                 firstframe = min(coll.indexes)
                 lastframe = max(coll.indexes)
-                filepath = os.path.join(
-                    directory_path,
-                    f"{basename}{'#' * coll.padding}{extension}"
-                ).replace('\\', '/')
+                filepath = f"{coll.head}{'#' * coll.padding}{coll.tail}"
     # Convert to relative path if requested
     if filepath and allow_relative and project_dir:
         filepath = os.path.relpath(filepath, project_dir)
-        filepath = filepath.replace('\\', '/')
+    filepath = filepath.replace('\\', '/')
 
     return filepath, firstframe, lastframe
 

--- a/client/ayon_nuke/startup/write_to_read.py
+++ b/client/ayon_nuke/startup/write_to_read.py
@@ -14,7 +14,7 @@ def detect_file_on_disk(
         project_dir: str,
         first_frame: int,
         allow_relative: bool
-) -> tuple[str, int, int] | None:
+) -> tuple[str | None, int, int]:
     """Detects a file or image sequence on disk and returns its path along
     with the first and last frame numbers.
 

--- a/client/ayon_nuke/startup/write_to_read.py
+++ b/client/ayon_nuke/startup/write_to_read.py
@@ -2,6 +2,7 @@ import re
 import os
 import glob
 import nuke
+import clique
 from ayon_core.lib import Logger
 log = Logger.get_logger(__name__)
 
@@ -9,76 +10,104 @@ SINGLE_FILE_FORMATS = ['avi', 'mp4', 'mxf', 'mov', 'mpg', 'mpeg', 'wmv', 'm4v',
                        'm2v']
 
 
-def evaluate_filepath_new(
-        k_value, k_eval, project_dir, first_frame, allow_relative):
+def detect_file_on_disk(
+        k_value: str,
+        k_eval: str,
+        project_dir: str,
+        first_frame: int,
+        allow_relative: bool
+) -> tuple[str, int, int] | None:
+    """Detects a file or image sequence on disk and returns its path along
+    with the first and last frame numbers.
 
-    # get combined relative path
+    Args:
+        k_value (str): The original file path pattern, potentially
+        containing frame padding token "%04d".
+        k_eval (str): The evaluated file path potentially with a specific
+        frame number.
+        project_dir (str): The root directory of the project.
+        first_frame (int): The first frame number to consider when detecting
+        the file sequence.
+        allow_relative (bool): Whether to return the file path as relative to
+        the project directory.
+
+    Returns:
+        tuple[str, int, int] | None: A tuple containing the file path,
+        first frame number, and last frame number if the file or sequence
+        is detected; otherwise, None.
+    """
     combined_relative_path = None
+    filepath = None
+    firstframe = first_frame
+    lastframe = first_frame
+    if not os.path.exists(k_eval):
+        raise FileNotFoundError(
+            "Cannot create Read node as the "
+            f"file does not exist: `{k_eval}`"
+        )
     if k_eval is not None and project_dir is not None:
         combined_relative_path = os.path.abspath(
-            os.path.join(project_dir, k_eval))
-        combined_relative_path = combined_relative_path.replace('\\', '/')
-        filetype = combined_relative_path.split('.')[-1]
-        frame_number = re.findall(r'\d+', combined_relative_path)[-1]
-        basename = combined_relative_path[: combined_relative_path.rfind(
-            frame_number)]
-        filepath_glob = basename + '*' + filetype
-        glob_search_results = glob.glob(filepath_glob)
-        if len(glob_search_results) <= 0:
-            combined_relative_path = None
+            os.path.join(project_dir, k_eval)
+        )
+    directory = os.path.dirname(k_eval)
+    if directory and not os.path.isdir(directory):
+        return None, 0, 0
 
-    try:
-        # k_value = k_value % first_frame
-        if os.path.isdir(os.path.basename(k_value)):
-            # doesn't check for file, only parent dir
-            filepath = k_value
-        elif os.path.exists(k_eval):
+    # Handle single file case (no frame padding)
+    if k_eval == k_value:
+        # If the evaluated path is the same as the original pattern,
+        # this means it does not contain any frame token
+        if os.path.exists(k_eval):
             filepath = k_eval
-        elif not isinstance(project_dir, type(None)) and \
-                not isinstance(combined_relative_path, type(None)):
-            filepath = combined_relative_path
 
-        filepath = os.path.abspath(filepath)
-    except Exception as E:
-        log.error("Cannot create Read node. Perhaps it needs to be \
-                  rendered first :) Error: `{}`".format(E))
-        return None
+        elif project_dir is not None:
+            # Try with project directory
+            combined_path = os.path.abspath(os.path.join(project_dir, k_eval))
+            if os.path.exists(combined_path):
+                filepath = combined_path
 
-    filepath = filepath.replace('\\', '/')
-    # assumes last number is a sequence counter
-    current_frame = re.findall(r'\d+', filepath)[-1]
-    padding = len(current_frame)
-    basename = filepath[: filepath.rfind(current_frame)]
-    filetype = filepath.split('.')[-1]
+        if filepath and allow_relative and project_dir is not None:
+            filepath = os.path.relpath(filepath, project_dir)
 
-    # sequence or not?
-    if filetype in SINGLE_FILE_FORMATS:
-        pass
-    else:
-        # Image sequence needs hashes
-        # to do still with no number not handled
-        filepath = basename + '#' * padding + '.' + filetype
+        return filepath, firstframe, lastframe
 
-    # relative path? make it relative again
-    if allow_relative:
-        if (not isinstance(project_dir, type(None))) and project_dir != "":
-            filepath = filepath.replace(project_dir, '.')
+    collections, _ = clique.assemble(
+        [combined_relative_path],
+        assume_padded_when_ambiguous=True,
+        patterns=[clique.PATTERNS['frames']]
+    )
 
-    # get first and last frame from disk
-    frames = []
-    firstframe = 0
-    lastframe = 0
-    filepath_glob = basename + '*' + filetype
-    glob_search_results = glob.glob(filepath_glob)
-    for f in glob_search_results:
-        frame = re.findall(r'\d+', f)[-1]
-        frames.append(frame)
-    frames = sorted(frames)
-    firstframe = frames[0]
-    lastframe = frames[len(frames) - 1]
+    collection = collections[0] if collections else None
+    if collection:
+        # Get all files in the directory to find all frames
+        files_in_dir = [
+            os.path.join(directory, f)
+            for f in os.listdir(directory)
+            if os.path.isfile(os.path.join(directory, f))
+        ]
 
-    if int(lastframe) < 0:
-        lastframe = firstframe
+        if files_in_dir:
+            # Assemble all files in directory to find the complete sequence
+            coll, _ = clique.assemble(
+                files_in_dir,
+                assume_padded_when_ambiguous=True,
+                patterns=[clique.PATTERNS['frames']]
+            )[0][0]
+            if coll.padding == collection.padding:
+                # Found matching sequence
+                directory_path = os.path.dirname(k_value)
+                basename = coll.head
+                extension = coll.tail
+                firstframe = min(coll.indexes)
+                lastframe = max(coll.indexes)
+                filepath = os.path.join(
+                    directory_path,
+                    f"{basename}{'#' * coll.padding}{extension}"
+                ).replace('\\', '/')
+    # Convert to relative path if requested
+    if filepath and allow_relative and project_dir:
+        filepath = os.path.relpath(filepath, project_dir)
+        filepath = filepath.replace('\\', '/')
 
     return filepath, firstframe, lastframe
 
@@ -121,7 +150,7 @@ def write_to_read(gn,
             n = group_writes[0]
 
             if n.knob('file') is not None:
-                myfile, firstFrame, lastFrame = evaluate_filepath_new(
+                myfile, firstFrame, lastFrame = detect_file_on_disk(
                     n.knob('file').getValue(),
                     n.knob('file').evaluate(),
                     project_dir,

--- a/client/ayon_nuke/startup/write_to_read.py
+++ b/client/ayon_nuke/startup/write_to_read.py
@@ -1,6 +1,4 @@
-import re
 import os
-import glob
 import nuke
 import clique
 from ayon_core.lib import Logger


### PR DESCRIPTION
## Changelog Description
This PR is to fix the single frame padding issue for image product when users use write node button.
Resolve https://github.com/ynput/ayon-nuke/issues/247

## Additional review information
n/a

## Testing notes:
For each image, pre-render and render instance creators:
1. Create an single frame instance to get a write container
2. Render locally through the "Render local" button
3. Load back the result through "Read from Rendered"